### PR TITLE
Refactor Msg server packet handling into handlers

### DIFF
--- a/AISpace.Common/Network/Handlers/AvatarGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AvatarGetDataHandler.cs
@@ -1,0 +1,24 @@
+using AISpace.Common.Network.Packets.Msg;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AvatarGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AvatarGetDataRequest;
+
+    public PacketType ResponseType => PacketType.Msg_AvatarDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var dataResponse = new AvatarDataResponse(0, "test", 1001011, 0, 0);
+        dataResponse.AddEquip(10100140, 0);
+        dataResponse.AddEquip(10200130, 0);
+        dataResponse.AddEquip(10100190, 0);
+        await connection.SendAsync(ResponseType, dataResponse.ToBytes(), ct);
+
+        var avatarGetDataResp = new AvatarGetDataResponse(0);
+        await connection.SendAsync(PacketType.AvatarGetDataResponse, avatarGetDataResp.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AvatarSelectHandler.cs
+++ b/AISpace.Common/Network/Handlers/AvatarSelectHandler.cs
@@ -1,0 +1,19 @@
+using AISpace.Common.Network.Packets.Msg;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AvatarSelectHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AvatarSelectRequest;
+
+    public PacketType ResponseType => PacketType.AvatarSelectResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        _ = AvatarSelectRequest.FromBytes(payload.Span);
+        var response = new AvatarSelectResponse(0);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/ChannelListGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/ChannelListGetHandler.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using AISpace.Common.Game;
+using AISpace.Common.Network.Packets.Msg;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class ChannelListGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.ChannelListGetRequest;
+
+    public PacketType ResponseType => PacketType.ChannelListGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        List<ChannelInfo> channels = [];
+        var serverInfo = new ServerInfo("127.0.0.1", 50054);
+        channels.Add(new ChannelInfo(0, 0, 1, serverInfo));
+        var response = new ChannelListGetResponse(0, channels);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/ChannelSelectHandler.cs
+++ b/AISpace.Common/Network/Handlers/ChannelSelectHandler.cs
@@ -1,0 +1,20 @@
+using AISpace.Common.Game;
+using AISpace.Common.Network.Packets.Msg;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class ChannelSelectHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.ChannelSelectRequest;
+
+    public PacketType ResponseType => PacketType.ChannelSelectResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        _ = ChannelSelectRequest.FromBytes(payload.Span);
+        var response = new ChannelSelectResponse(0, new ServerInfo("127.0.0.1", 50054), 10990200, 10990200);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/CircleGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/CircleGetDataHandler.cs
@@ -1,0 +1,19 @@
+namespace AISpace.Common.Network.Handlers;
+
+public class CircleGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.CircleGetDataRequest;
+
+    public PacketType ResponseType => PacketType.CircleGetDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        using PacketWriter writer = new();
+        writer.Write((uint)0); // Result
+        writer.Write((uint)0); // circle_data
+        writer.Write((uint)0); // auth_level
+        await connection.SendAsync(ResponseType, writer.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/ItemGetBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/ItemGetBaseListHandler.cs
@@ -1,0 +1,18 @@
+using AISpace.Common.Network.Packets.Msg;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class ItemGetBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.ItemGetBaseListRequest;
+
+    public PacketType ResponseType => PacketType.ItemGetBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new ItemGetBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/LoginHandler.cs
+++ b/AISpace.Common/Network/Handlers/LoginHandler.cs
@@ -1,0 +1,24 @@
+using System.Text;
+using AISpace.Common.Network.Packets.Msg;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class LoginHandler : IPacketHandler
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public PacketType RequestType => PacketType.LoginRequest;
+
+    public PacketType ResponseType => PacketType.LoginResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var loginReq = LoginRequest.FromBytes(payload.Span);
+        var otp = Encoding.ASCII.GetString(loginReq.OTP);
+        _logger.Info($"Client: {connection.Id} LoginRequest UserID: {loginReq.UserID}, OTP: {otp}");
+        await connection.SendAsync(ResponseType, new LoginResponse().ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/MailBoxGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/MailBoxGetDataHandler.cs
@@ -1,0 +1,18 @@
+namespace AISpace.Common.Network.Handlers;
+
+public class MailBoxGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MailBoxGetDataRequest;
+
+    public PacketType ResponseType => PacketType.MailBoxGetDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        using PacketWriter writer = new();
+        writer.Write((uint)0); // Result
+        writer.Write((uint)0); // mail
+        await connection.SendAsync(ResponseType, writer.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/MsgVersionCheckHandler.cs
+++ b/AISpace.Common/Network/Handlers/MsgVersionCheckHandler.cs
@@ -1,0 +1,19 @@
+using AISpace.Common.Network.Packets.Common;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class MsgVersionCheckHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.Msg_VersionCheckRequest;
+
+    public PacketType ResponseType => PacketType.Msg_VersionCheckResponse;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var req = VersionCheckRequest.FromBytes(payload.Span);
+        var resp = new VersionCheckResponse(0, req.Major, req.Minor, req.Version);
+        await connection.SendAsync(ResponseType, resp.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/PostTalkHandler.cs
+++ b/AISpace.Common/Network/Handlers/PostTalkHandler.cs
@@ -1,0 +1,22 @@
+using AISpace.Common.Network.Packets.Msg;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class PostTalkHandler : IPacketHandler
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public PacketType RequestType => PacketType.PostTalkRequest;
+
+    public PacketType ResponseType => PacketType.PostTalkRequest;
+
+    public MessageDomain Domains => MessageDomain.Msg;
+
+    public Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var chatMessage = PostTalkRequest.FromBytes(payload.Span);
+        _logger.Info($"User says {chatMessage.Message} | MID{chatMessage.MessageID} | DID{chatMessage.DistID} | BID{chatMessage.BalloonID}");
+        return Task.CompletedTask;
+    }
+}

--- a/AISpace.Msg.Server/MsgServer.cs
+++ b/AISpace.Msg.Server/MsgServer.cs
@@ -1,10 +1,6 @@
-﻿using System.Net.Sockets;
-using System.Text;
-using AISpace.Common.Game;
+using System.Collections.Generic;
 using AISpace.Common.Network;
-using AISpace.Common.Network.Packets;
-using AISpace.Common.Network.Packets.Common;
-using AISpace.Common.Network.Packets.Msg;
+using AISpace.Common.Network.Handlers;
 using NLog;
 
 namespace AISpace.Msg.Server;
@@ -14,6 +10,20 @@ public class MsgServer(int port = 50052)
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
     private readonly TcpListenerService tcpServer = new("0.0.0.0", port, false);
+    private readonly Dictionary<PacketType, IPacketHandler> _handlers = new()
+    {
+        { PacketType.Ping, new PingHandler() },
+        { PacketType.Msg_VersionCheckRequest, new MsgVersionCheckHandler() },
+        { PacketType.ItemGetBaseListRequest, new ItemGetBaseListHandler() },
+        { PacketType.LoginRequest, new LoginHandler() },
+        { PacketType.AvatarGetDataRequest, new AvatarGetDataHandler() },
+        { PacketType.AvatarSelectRequest, new AvatarSelectHandler() },
+        { PacketType.ChannelListGetRequest, new ChannelListGetHandler() },
+        { PacketType.ChannelSelectRequest, new ChannelSelectHandler() },
+        { PacketType.MailBoxGetDataRequest, new MailBoxGetDataHandler() },
+        { PacketType.CircleGetDataRequest, new CircleGetDataHandler() },
+        { PacketType.PostTalkRequest, new PostTalkHandler() },
+    };
 
     public async void Start()
     {
@@ -21,88 +31,14 @@ public class MsgServer(int port = 50052)
         tcpServer.Start();
         await foreach (var packet in tcpServer.PacketReader.ReadAllAsync())
         {
-            ClientConnection Client = packet.Client;
-            string ClientID = packet.Client.Id.ToString();
-            var payload = packet.Data;
-            switch (packet.Type)
+            if (_handlers.TryGetValue(packet.Type, out var handler) && handler.Domains.HasFlag(MessageDomain.Msg))
             {
-                case PacketType.Ping:
-                    _ = Client.SendAsync(PacketType.Ping, PingRequest.FromBytes(payload).ToBytes());
-                    break;
-                case PacketType.Msg_VersionCheckRequest:
-                    var req = VersionCheckRequest.FromBytes(payload);
-                    _ = Client.SendAsync(PacketType.Msg_VersionCheckResponse, new VersionCheckResponse(0, req.Major, req.Minor, req.Version).ToBytes());
-                    break;
-                case PacketType.ItemGetBaseListRequest:
-                    _ = Client.SendAsync(PacketType.ItemGetBaseListResponse, new ItemGetBaseListResponse().ToBytes());
-                    break;
-                case PacketType.LoginRequest:
-                    var loginReq = LoginRequest.FromBytes(payload);
-                    var otp = Encoding.ASCII.GetString(loginReq.OTP);
-                    _logger.Info($"Client: {ClientID} LoginRequest UserID: {loginReq.UserID}, OTP: {otp}");
-                    _ = Client.SendAsync(PacketType.LoginResponse, new LoginResponse().ToBytes());
-                    break;
-                case PacketType.AvatarGetDataRequest:
-                    //Get Character information from database
-                    var DataResp = new AvatarDataResponse(0,"test", 1001011, 0, 0);
-                    //Get Equipment from Database.
-                    DataResp.AddEquip(10100140, 0);
-                    DataResp.AddEquip(10200130, 0);
-                    DataResp.AddEquip(10100190, 0);
-                    _ = Client.SendAsync(PacketType.Msg_AvatarDataResponse, DataResp.ToBytes());
-                    var avatarGetDataResp = new AvatarGetDataResponse(0);
-                    _ = Client.SendAsync(PacketType.AvatarGetDataResponse, avatarGetDataResp.ToBytes());
-                        break;
-                case PacketType.AvatarSelectRequest:
-                    var avatarRequest = AvatarSelectRequest.FromBytes(payload);
-                    var avatarResp = new AvatarSelectResponse(0);
-                    _ = Client.SendAsync(PacketType.AvatarSelectResponse, avatarResp.ToBytes());
-                    break;
-                case PacketType.ChannelListGetRequest:
-                    List<ChannelInfo> channels = [];
-                    var servInfo = new ServerInfo("127.0.0.1", 50054);
-                    channels.Add(new ChannelInfo(0, 0, 1, servInfo));
-                    var channelListResp = new ChannelListGetResponse(0, channels);
-                    _ = Client.SendAsync(PacketType.ChannelListGetResponse, channelListResp.ToBytes());
-                    break;
-                case PacketType.ChannelSelectRequest:
-                    var channelSelectReq = ChannelSelectRequest.FromBytes(payload);
-
-                    //10990100
-                    //10990110
-                    var channelSelectResp = new ChannelSelectResponse(0, new ServerInfo("127.0.0.1", 50054), 10990200, 10990200);
-                    _ = Client.SendAsync(PacketType.ChannelSelectResponse, channelSelectResp.ToBytes());
-                    break;
-                case PacketType.MailBoxGetDataRequest:
-                    using (PacketWriter writer = new())
-                    {
-                        writer.Write((uint)0);//Result
-                        writer.Write((uint)0); // mail
-                        _ = Client.SendAsync(PacketType.MailBoxGetDataResponse, writer.ToBytes());
-                    }
-                    break;
-                case PacketType.CircleGetDataRequest:
-                    using (PacketWriter writer = new())
-                    {
-                        writer.Write((uint)0);//Result
-                        writer.Write((uint)0); // circle_data
-                        writer.Write((uint)0); // auth_level
-                        _ = Client.SendAsync(PacketType.CircleGetDataResponse, writer.ToBytes());
-                    }
-                    break;
-                case PacketType.PostTalkRequest:
-                    var chatMessage = PostTalkRequest.FromBytes(payload);
-                    //_ = Client.SendAsync(PacketType.PostTalkRequest, chatMessage.ToBytes());
-                    _logger.Info($"User says {chatMessage.Message} | MID{chatMessage.MessageID} | DID{chatMessage.DistID} | BID{chatMessage.BalloonID}");
-                    break;
-                default:
-                        _logger.Error($"Msg: Unknown packet type: {packet.RawType:X4}");
-                        break;
+                await handler.HandleAsync(packet.Data, packet.Client);
             }
-
-
-
+            else
+            {
+                _logger.Error($"Msg: Unknown packet type: {packet.RawType:X4}");
+            }
         }
-
     }
 }


### PR DESCRIPTION
## Summary
- replace the Msg server switch statement with a dictionary of IPacketHandler instances
- add dedicated handlers for version check, login, avatar data/select, channel list/select, mailbox, circle, item base list, and post talk packets

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf901588148329baa1ea8843246dc0