### PR TITLE
Refactor area server packet handling into dedicated handlers

### DIFF
--- a/AISpace.Area.Server/AreaServer.cs
+++ b/AISpace.Area.Server/AreaServer.cs
@@ -1,10 +1,8 @@
-﻿using System.IO.Compression;
-using System.Numerics;
-using AISpace.Common.Game;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using AISpace.Common.Network;
-using AISpace.Common.Network.Packets;
-using AISpace.Common.Network.Packets.Area;
-using AISpace.Common.Network.Packets.Common;
+using AISpace.Common.Network.Handlers;
 using NLog;
 
 namespace AISpace.Area.Server;
@@ -12,6 +10,41 @@ namespace AISpace.Area.Server;
 public class AreaServer(int port = 50054)
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    private static readonly IReadOnlyList<IPacketHandler> _handlers = new IPacketHandler[]
+    {
+        new PingHandler(),
+        new AreaVersionCheckHandler(),
+        new AreasvEnterHandler(),
+        new AreaAvatarGetDataHandler(),
+        new AreaRoboGetListHandler(),
+        new AreaItemGetListHandler(),
+        new AreaEquipOrderListHandler(),
+        new AreaFurnitureGetBaseListHandler(),
+        new AreaEmotionGetBaseListHandler(),
+        new AreaUccAdvFigureBaseListHandler(),
+        new AreaUccVoiceBaseListHandler(),
+        new AreaNiconiCommonsBaseListHandler(),
+        new AreaMissionDataHandler(),
+        new AreaMapDataEnterEndHandler(),
+        new AreaFriendLinkTagGetHandler(),
+        new AreaFriendGetListDataHandler(),
+        new AreaEmotionGetObtainedListHandler(),
+        new AreaHeroineGetTicketBaseHandler(),
+        new AreaNpcGetDataHandler(),
+        new AreaMapLinkGetDataHandler(),
+        new AreaMyRoomGetFurnitureHandler(),
+        new AreaTimeZoneGetHandler(),
+        new AreaMascotGetCountHandler(),
+        new AreaMoneyDataGetHandler(),
+        new AreaAiDownloadListGetHandler(),
+        new AreaAiUploadRateGetHandler(),
+        new AreaUpdateOptionHandler(),
+        new AreasvLeaveHandler(),
+        new AreaRoboVoiceTypeUpdateHandler(),
+        new AreaMapEnterHandler(),
+        new AreaNotifyMoveDataHandler(),
+    };
 
     private readonly TcpListenerService tcpServer = new("0.0.0.0", port, false);
 
@@ -21,160 +54,20 @@ public class AreaServer(int port = 50054)
         tcpServer.Start();
         await foreach (var packet in tcpServer.PacketReader.ReadAllAsync())
         {
-            ClientConnection Client = packet.Client;
-            string ClientID = packet.Client.Id.ToString();
-            var payload = packet.Data;
-            //if(packet.Type != PacketType.Ping)
-            //    _logger.Info($"Client: Area {packet.Type}");
-            switch (packet.Type)
+            var handler = _handlers.FirstOrDefault(h => h.RequestType == packet.Type && h.Domains.HasFlag(MessageDomain.Area));
+
+            if (handler is null)
             {
-                case PacketType.Ping:
-                    var ping = PingRequest.FromBytes(payload);
-                    Client.lastPing = DateTimeOffset.Now;
-                    _ = Client.SendAsync(PacketType.Ping, ping.ToBytes());
-                    break;
-                case PacketType.Msg_VersionCheckRequest:
-                    var req = VersionCheckRequest.FromBytes(payload);
-                    _logger.Info($"Client: {ClientID} Version: {packet.Client.Version}");
-                    var resp = new VersionCheckResponse(0, req.Major, req.Minor, req.Version);
-                    _ = Client.SendAsync(PacketType.Msg_VersionCheckResponse, resp.ToBytes());
-                    break;
-                case PacketType.AreasvEnterRequest:
-                    var enterReq = AreasvEnterRequest.FromBytes(payload);
-                    _logger.Info($"Client: {ClientID} EnterRequest UserID: {enterReq.UserID}, SessionID: {enterReq.OTP}");
-                    //Need to check UserID and OTP
-
-                    //Change enterResp so if UserID and OTP is wrong it responds with result 1
-                    //Change enterResp to have the correct ID for the user
-                    var enterResp = new AreasvEnterResponse(0, 25);
-                    _ = Client.SendAsync(PacketType.AreasvEnterResponse, enterResp.ToBytes());
-                    _ = Task.Run(async () =>
-                    {
-                        await Task.Delay(10000);
-                        _logger.Info($"Attempting to add Avatar");
-                        //0 X -227.392 Y -0.043 Z -1418.097 Yaw047 D0
-                        var charaData = new CharaData(24, 24, "randomuser");
-                        charaData.AddEquip(10100140, 0);
-                        charaData.AddEquip(10200130, 0);
-                        charaData.AddEquip(10100190, 0);
-                        //Need to set AvatarData ID
-                        var avatarData = new AvatarData(1, charaData);
-                        var notifyData = new AvatarNotifyData(0, avatarData);
-                        await Task.Delay(1000);
-
-                        var moveData = new MovementData(-227.392f, -0.043f, -1418.097f, -119, 0);
-                        var moveNotify = new AvatarNotifyMove(24, moveData);
-                        _ = Client.SendAsync(PacketType.AvatarNotifyMove, moveNotify.ToBytes());
-
-
-                        //result: 0 X-7363.452 Y2.509 Z-16686.670 Yaw-119 D0
-                        //var moveData = new MoveData(new Vector3(-7363f, -2.5f, -16686f), -119, 0);
-                        //var moveNotify = new AvatarNotifyMove(22, moveData);
-                        //_ = Client.SendAsync(PacketType.AvatarNotifyMove, moveNotify.ToBytes());
-                    });
-                    
-                    break;
-                case PacketType.AvatarGetDataRequest:
-                    _logger.Info(BitConverter.ToString(payload));
-                    //Need to set chara ID
-                    var charaData = new CharaData(23, 23, "test");
-                    charaData.AddEquip(10100140, 0);
-                    charaData.AddEquip(10200130, 0);
-                    charaData.AddEquip(10100190, 0);
-                    //Need to set AvatarData ID
-                    var avatarData = new AvatarData(0, charaData);
-                    var notifyData = new AvatarNotifyData(0, avatarData);
-                    _ = Client.SendAsync(PacketType.AvatarNotifyData, notifyData.ToBytes());
-                    break;
-                case PacketType.RoboGetListRequest:
-                    _ = Client.SendAsync(PacketType.RoboGetListResponse, new RoboGetListResponse().ToBytes());
-                    break;
-                case PacketType.ItemGetListRequest:
-                    _ = Client.SendAsync(PacketType.ItemGetListResponse, new ItemGetListResponse(0).ToBytes());
-                    break;
-                case PacketType.EquipOrderListRequest:
-                    _ = Client.SendAsync(PacketType.EquipOrderListResponse, new EquipOrderListResponse().ToBytes());
-                    break;
-                case PacketType.FurnitureGetBaseListRequest:
-                    _ = Client.SendAsync(PacketType.FurnitureGetBaseListResponse, new FurnitureGetBaseListResponse().ToBytes());
-                    break;
-                case PacketType.EmotionGetBaseListRequest:
-                    _ = Client.SendAsync(PacketType.EmotionGetBaseListResponse, new EmotionGetBaseListResponse().ToBytes());
-                    break;
-                case PacketType.UccAdvFigureBaseListRequest:
-                    _ = Client.SendAsync(PacketType.UccAdvFigureBaseListResponse, new UccAdvFigureBaseListResponse().ToBytes());
-                    break;
-                case PacketType.UccVoiceBaseListRequest:
-                    _ = Client.SendAsync(PacketType.UccVoiceBaseListResponse, new UccVoiceBaseListResponse().ToBytes());
-                    break;
-                case PacketType.NiconiCommonsBaseListRequest:
-                    _ = Client.SendAsync(PacketType.NiconiCommonsBaseListResponse, new NiconiCommonsBaseListResponse().ToBytes());
-                    break;
-                case PacketType.MissionDataRequest:
-                    _ = Client.SendAsync(PacketType.MissionDataResponse, new MissionDataResponse().ToBytes());
-                    break;
-                case PacketType.MapDataEnterEndRequest:
-                    _ = Client.SendAsync(PacketType.MapDataEnterEndResponse, new MapDataEnterEndResponse().ToBytes());
-                    break;
-                case PacketType.FriendLinkTagGetRequest:
-                    _ = Client.SendAsync(PacketType.FriendLinkTagGetResponse, new FriendLinkTagGetResponse().ToBytes());
-                    break;
-                case PacketType.FriendGetListDataRequest:
-                    _ = Client.SendAsync(PacketType.FriendGetListDataResponse, new FriendGetListDataResponse().ToBytes());
-                    break;
-                case PacketType.EmotionGetObtainedListRequest:
-                    _ = Client.SendAsync(PacketType.EmotionGetObtainedListResponse, new EmotionGetObtainedListResponse().ToBytes());
-                    break;
-                case PacketType.HeroineGetTicketBaseRequest:
-                    _ = Client.SendAsync(PacketType.HeroineGetTicketBaseResponse, new HeroineGetTicketBaseResponse().ToBytes());
-                    break;
-                case PacketType.NpcGetDataRequest:
-                    _ = Client.SendAsync(PacketType.NpcGetDataResponse, new NpcGetDataResponse().ToBytes());
-                    break;
-                case PacketType.MapLinkGetDataRequest:
-                    _ = Client.SendAsync(PacketType.MapLinkGetDataResponse, new MapLinkGetDataResponse().ToBytes());
-                    break;
-                case PacketType.MyRoomGetFurnitureRequest:
-                    _ = Client.SendAsync(PacketType.MyRoomGetFurnitureResponse, new MyRoomGetFurnitureResponse().ToBytes());
-                    break;
-                case PacketType.TimeZoneGetRequest:
-                    _ = Client.SendAsync(PacketType.TimeZoneGetResponse, new TimeZoneGetResponse(0,1,0,8,0).ToBytes());
-                    break;
-                case PacketType.MascotGetCountRequest:
-                    _ = Client.SendAsync(PacketType.MascotGetCountResponse, new MascotGetCountResponse().ToBytes());
-                    break;
-                case PacketType.MoneyDataGetRequest:
-                    _ = Client.SendAsync(PacketType.MoneyDataGetResponse, new MoneyDataGetResponse().ToBytes());
-                    break;
-                case PacketType.AiDownloadListGetRequest:
-                    _ = Client.SendAsync(PacketType.AiDownloadListGetResponse, new AiDownloadListGetResponse().ToBytes());
-                    break;
-                case PacketType.AiUploadRateGetRequest:
-                    _ = Client.SendAsync(PacketType.AiUploadRateGetResponse, new AiUploadRateGetResponse().ToBytes());
-                    break;
-                case PacketType.UpdateOptionRequest:
-                    _ = Client.SendAsync(PacketType.UpdateOptionResponse, new UpdateOptionResponse().ToBytes());
-                    break;
-                case PacketType.AreasvLeaveRequest:
-                    _ = Client.SendAsync(PacketType.AreasvLeaveResponse, new AreasvLeaveResponse().ToBytes());
-                    break;
-                case PacketType.RoboVoiceTypeUpdateRequest:
-                    _ = Client.SendAsync(PacketType.RoboVoiceTypeUpdateResponse, new RoboVoiceTypeUpdateResponse().ToBytes());
-                    break;
-                case PacketType.MapEnterRequest:
-                    _ = Client.SendAsync(PacketType.MapEnterResponse, new MapEnterResponse().ToBytes());
-                    break;
-                case PacketType.NotifyMoveData:
-                    AvatarMove am = AvatarMove.FromBytes(payload);
-                    _logger.Info($"AvatarMove: [{string.Join(", ", payload)}]");
-                    var md1 = am.Moves[0];
-                    var md1p = md1.Position;
-                    _logger.Info($"result: {am.Result} X{md1p.X:0.000} Y{md1p.Y:0.000} Z{md1p.Z:0.000} Yaw{md1.Rotation:000} D{md1.Animation:0}");
-                    break;
-                default:
-                    _logger.Error($"Area: Unknown packet type: {packet.RawType:X4}");
-                    break;
+                _logger.Error($"Area: Unknown packet type: {packet.RawType:X4}");
+                continue;
             }
+
+            if (packet.Type == PacketType.Ping)
+            {
+                packet.Client.lastPing = DateTimeOffset.Now;
+            }
+
+            await handler.HandleAsync(packet.Data, packet.Client);
         }
 
     }

--- a/AISpace.Common/Network/Handlers/AreaAiDownloadListGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaAiDownloadListGetHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaAiDownloadListGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AiDownloadListGetRequest;
+
+    public PacketType ResponseType => PacketType.AiDownloadListGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new AiDownloadListGetResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaAiUploadRateGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaAiUploadRateGetHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaAiUploadRateGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AiUploadRateGetRequest;
+
+    public PacketType ResponseType => PacketType.AiUploadRateGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new AiUploadRateGetResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaAvatarGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaAvatarGetDataHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Game;
+using AISpace.Common.Network.Packets.Area;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaAvatarGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AvatarGetDataRequest;
+
+    public PacketType ResponseType => PacketType.AvatarNotifyData;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        _logger.Info(BitConverter.ToString(payload.Span));
+        var charaData = new CharaData(23, 23, "test");
+        charaData.AddEquip(10100140, 0);
+        charaData.AddEquip(10200130, 0);
+        charaData.AddEquip(10100190, 0);
+        var avatarData = new AvatarData(0, charaData);
+        var notifyData = new AvatarNotifyData(0, avatarData);
+        await connection.SendAsync(ResponseType, notifyData.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaEmotionGetBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaEmotionGetBaseListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaEmotionGetBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.EmotionGetBaseListRequest;
+
+    public PacketType ResponseType => PacketType.EmotionGetBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new EmotionGetBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaEmotionGetObtainedListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaEmotionGetObtainedListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaEmotionGetObtainedListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.EmotionGetObtainedListRequest;
+
+    public PacketType ResponseType => PacketType.EmotionGetObtainedListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new EmotionGetObtainedListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaEquipOrderListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaEquipOrderListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaEquipOrderListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.EquipOrderListRequest;
+
+    public PacketType ResponseType => PacketType.EquipOrderListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new EquipOrderListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaFriendGetListDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaFriendGetListDataHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaFriendGetListDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.FriendGetListDataRequest;
+
+    public PacketType ResponseType => PacketType.FriendGetListDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new FriendGetListDataResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaFriendLinkTagGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaFriendLinkTagGetHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaFriendLinkTagGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.FriendLinkTagGetRequest;
+
+    public PacketType ResponseType => PacketType.FriendLinkTagGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new FriendLinkTagGetResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaFurnitureGetBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaFurnitureGetBaseListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaFurnitureGetBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.FurnitureGetBaseListRequest;
+
+    public PacketType ResponseType => PacketType.FurnitureGetBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new FurnitureGetBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaHeroineGetTicketBaseHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaHeroineGetTicketBaseHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaHeroineGetTicketBaseHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.HeroineGetTicketBaseRequest;
+
+    public PacketType ResponseType => PacketType.HeroineGetTicketBaseResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new HeroineGetTicketBaseResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaItemGetListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaItemGetListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaItemGetListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.ItemGetListRequest;
+
+    public PacketType ResponseType => PacketType.ItemGetListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new ItemGetListResponse(0);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMapDataEnterEndHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMapDataEnterEndHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMapDataEnterEndHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MapDataEnterEndRequest;
+
+    public PacketType ResponseType => PacketType.MapDataEnterEndResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MapDataEnterEndResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMapEnterHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMapEnterHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMapEnterHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MapEnterRequest;
+
+    public PacketType ResponseType => PacketType.MapEnterResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MapEnterResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMapLinkGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMapLinkGetDataHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMapLinkGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MapLinkGetDataRequest;
+
+    public PacketType ResponseType => PacketType.MapLinkGetDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MapLinkGetDataResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMascotGetCountHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMascotGetCountHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMascotGetCountHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MascotGetCountRequest;
+
+    public PacketType ResponseType => PacketType.MascotGetCountResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MascotGetCountResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMissionDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMissionDataHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMissionDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MissionDataRequest;
+
+    public PacketType ResponseType => PacketType.MissionDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MissionDataResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMoneyDataGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMoneyDataGetHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMoneyDataGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MoneyDataGetRequest;
+
+    public PacketType ResponseType => PacketType.MoneyDataGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MoneyDataGetResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaMyRoomGetFurnitureHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaMyRoomGetFurnitureHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaMyRoomGetFurnitureHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.MyRoomGetFurnitureRequest;
+
+    public PacketType ResponseType => PacketType.MyRoomGetFurnitureResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new MyRoomGetFurnitureResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaNiconiCommonsBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaNiconiCommonsBaseListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaNiconiCommonsBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.NiconiCommonsBaseListRequest;
+
+    public PacketType ResponseType => PacketType.NiconiCommonsBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new NiconiCommonsBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaNotifyMoveDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaNotifyMoveDataHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaNotifyMoveDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.NotifyMoveData;
+
+    public PacketType ResponseType => PacketType.NotifyMoveData;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var avatarMove = AvatarMove.FromBytes(payload.Span);
+        var payloadBytes = payload.ToArray();
+        _logger.Info($"AvatarMove: [{string.Join(", ", payloadBytes)}]");
+        var movement = avatarMove.Moves[0];
+        _logger.Info($"result: {avatarMove.Result} X{movement.X:0.000} Y{movement.Y:0.000} Z{movement.Z:0.000} Yaw{movement.Rotation:000} D{(byte)movement.Animation:0}");
+        return Task.CompletedTask;
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaNpcGetDataHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaNpcGetDataHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaNpcGetDataHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.NpcGetDataRequest;
+
+    public PacketType ResponseType => PacketType.NpcGetDataResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new NpcGetDataResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaRoboGetListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaRoboGetListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaRoboGetListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.RoboGetListRequest;
+
+    public PacketType ResponseType => PacketType.RoboGetListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new RoboGetListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaRoboVoiceTypeUpdateHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaRoboVoiceTypeUpdateHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaRoboVoiceTypeUpdateHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.RoboVoiceTypeUpdateRequest;
+
+    public PacketType ResponseType => PacketType.RoboVoiceTypeUpdateResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new RoboVoiceTypeUpdateResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaTimeZoneGetHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaTimeZoneGetHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaTimeZoneGetHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.TimeZoneGetRequest;
+
+    public PacketType ResponseType => PacketType.TimeZoneGetResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new TimeZoneGetResponse(0, 1, 0, 8, 0);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaUccAdvFigureBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaUccAdvFigureBaseListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaUccAdvFigureBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.UccAdvFigureBaseListRequest;
+
+    public PacketType ResponseType => PacketType.UccAdvFigureBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new UccAdvFigureBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaUccVoiceBaseListHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaUccVoiceBaseListHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaUccVoiceBaseListHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.UccVoiceBaseListRequest;
+
+    public PacketType ResponseType => PacketType.UccVoiceBaseListResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new UccVoiceBaseListResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaUpdateOptionHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaUpdateOptionHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaUpdateOptionHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.UpdateOptionRequest;
+
+    public PacketType ResponseType => PacketType.UpdateOptionResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new UpdateOptionResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreaVersionCheckHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreaVersionCheckHandler.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Common;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreaVersionCheckHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.Msg_VersionCheckRequest;
+
+    public PacketType ResponseType => PacketType.Msg_VersionCheckResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var req = VersionCheckRequest.FromBytes(payload.Span);
+        _logger.Info($"Client: {connection.Id} Version: {connection.Version}");
+        var resp = new VersionCheckResponse(0, req.Major, req.Minor, req.Version);
+        await connection.SendAsync(ResponseType, resp.ToBytes(), ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreasvEnterHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreasvEnterHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Game;
+using AISpace.Common.Network.Packets.Area;
+using NLog;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreasvEnterHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AreasvEnterRequest;
+
+    public PacketType ResponseType => PacketType.AreasvEnterResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var req = AreasvEnterRequest.FromBytes(payload.Span);
+        _logger.Info($"Client: {connection.Id} EnterRequest UserID: {req.UserID}, SessionID: {req.OTP}");
+
+        var response = new AreasvEnterResponse(0, 25);
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10), ct);
+                _logger.Info("Attempting to add Avatar");
+                var charaData = new CharaData(24, 24, "randomuser");
+                charaData.AddEquip(10100140, 0);
+                charaData.AddEquip(10200130, 0);
+                charaData.AddEquip(10100190, 0);
+                var avatarData = new AvatarData(1, charaData);
+                _ = new AvatarNotifyData(0, avatarData);
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+
+                var moveData = new MovementData(-227.392f, -0.043f, -1418.097f, -119, MovementType.Stopped);
+                var moveNotify = new AvatarNotifyMove(24, moveData);
+                await connection.SendAsync(PacketType.AvatarNotifyMove, moveNotify.ToBytes(), ct);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }, ct);
+    }
+}

--- a/AISpace.Common/Network/Handlers/AreasvLeaveHandler.cs
+++ b/AISpace.Common/Network/Handlers/AreasvLeaveHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AISpace.Common.Network.Packets.Area;
+
+namespace AISpace.Common.Network.Handlers;
+
+public class AreasvLeaveHandler : IPacketHandler
+{
+    public PacketType RequestType => PacketType.AreasvLeaveRequest;
+
+    public PacketType ResponseType => PacketType.AreasvLeaveResponse;
+
+    public MessageDomain Domains => MessageDomain.Area;
+
+    public async Task HandleAsync(ReadOnlyMemory<byte> payload, ClientConnection connection, CancellationToken ct = default)
+    {
+        var response = new AreasvLeaveResponse();
+        await connection.SendAsync(ResponseType, response.ToBytes(), ct);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the AreaServer switch with handler-based dispatch for area packets
- add IPacketHandler implementations for each area packet to encapsulate responses and logging

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf93e334208329a33e63d51fa14088