### PR TITLE
Remove OnTick from auth server. Lower default tick Rate

### DIFF
--- a/AISpace.Common.Tests/PacketDispatcherTests.cs
+++ b/AISpace.Common.Tests/PacketDispatcherTests.cs
@@ -72,6 +72,7 @@ public class PacketDispatcherTests
         var services = new ServiceCollection();
         services.AddSingleton(sink);
         services.AddScoped<IPacketHandler, RecordingAuthAuthenticateHandler>();
+        services.AddScoped<RecordingAuthAuthenticateHandler>();
         services.AddSingleton<ILogger<PacketDispatcher>>(NullLogger<PacketDispatcher>.Instance);
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton<PacketDispatcher>();
@@ -93,6 +94,7 @@ public class PacketDispatcherTests
         var services = new ServiceCollection();
         services.AddSingleton(sink);
         services.AddScoped<IPacketHandler, AuthPingOnlyHandler>();
+        services.AddScoped<AuthPingOnlyHandler>();
         services.AddSingleton<ILogger<PacketDispatcher>>(NullLogger<PacketDispatcher>.Instance);
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton<PacketDispatcher>();
@@ -112,6 +114,7 @@ public class PacketDispatcherTests
         var services = new ServiceCollection();
         services.AddSingleton(sink);
         services.AddScoped<IPacketHandler, AuthRequiredPingHandler>();
+        services.AddScoped<AuthRequiredPingHandler>();
         services.AddSingleton<ILogger<PacketDispatcher>>(NullLogger<PacketDispatcher>.Instance);
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton<PacketDispatcher>();
@@ -131,6 +134,7 @@ public class PacketDispatcherTests
         var services = new ServiceCollection();
         services.AddSingleton(sink);
         services.AddScoped<IPacketHandler, AuthRequiredPingHandler>();
+        services.AddScoped<AuthRequiredPingHandler>();
         services.AddSingleton<ILogger<PacketDispatcher>>(NullLogger<PacketDispatcher>.Instance);
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton<PacketDispatcher>();

--- a/AISpace.Common/Config/ServerOptions.cs
+++ b/AISpace.Common/Config/ServerOptions.cs
@@ -19,11 +19,11 @@ public class ServerOptions
     /// <summary>Idle read timeout in seconds for client TCP connections. Handlers are released when no data arrives within this window.</summary>
     public int ClientReadTimeoutSeconds { get; set; } = 300;
 
-    /// <summary>Game loop tick rate in Hz for Auth, Msg, and Area background servers.</summary>
-    public int TickRateHz { get; set; } = 60;
+    /// <summary>Game loop tick rate in Hz for the Msg server (internal message queue polling).</summary>
+    public int TickRateHz { get; set; } = 10;
 
     /// <summary>When false, session presence is kept in-memory (single-node VPS). When true, SessionPresences table is used (multi-instance).</summary>
-    public bool UseDistributedSessionPresence { get; set; } = true;
+    public bool UseDistributedSessionPresence { get; set; } = false;
 
     public GameServerConfig AuthServer { get; set; } = new() { Port = 50050 };
     public GameServerConfig MsgServer { get; set; } = new() { Port = 50052 };

--- a/AISpace.Common/Config/ServerOptions.cs
+++ b/AISpace.Common/Config/ServerOptions.cs
@@ -19,9 +19,6 @@ public class ServerOptions
     /// <summary>Idle read timeout in seconds for client TCP connections. Handlers are released when no data arrives within this window.</summary>
     public int ClientReadTimeoutSeconds { get; set; } = 300;
 
-    /// <summary>Game loop tick rate in Hz for the Msg server (internal message queue polling).</summary>
-    public int TickRateHz { get; set; } = 10;
-
     /// <summary>When false, session presence is kept in-memory (single-node VPS). When true, SessionPresences table is used (multi-instance).</summary>
     public bool UseDistributedSessionPresence { get; set; } = false;
 

--- a/AISpace.Common/Game/SharedState.cs
+++ b/AISpace.Common/Game/SharedState.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using AISpace.Common.DAL.Repositories;
 
 namespace AISpace.Common.Game;
@@ -11,8 +12,7 @@ public class SharedState
     private readonly ISessionPresenceRepository? _sessionPresenceRepository;
     private readonly IPendingMapTransferRepository? _pendingMapTransferRepository;
 
-    private readonly Queue<(string id, string message)> _newMessages = new();
-    private readonly object _newMessagesLock = new();
+    private readonly Channel<(string Id, string Message)> _messages = Channel.CreateUnbounded<(string Id, string Message)>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
 
     public IReadOnlyCollection<IPlayerSession> AuthClients => GetServerClients(ServerType.Auth);
     public IReadOnlyCollection<IPlayerSession> MsgClients => GetServerClients(ServerType.Msg);
@@ -82,21 +82,9 @@ public class SharedState
         return _pendingMapTransferRepository.TryTake(userId, out transition);
     }
 
-    public void EnqueueMessage(string id, string message)
-    {
-        lock (_newMessagesLock)
-        {
-            _newMessages.Enqueue((id, message));
-        }
-    }
+    public void EnqueueMessage(string id, string message) => _messages.Writer.TryWrite((id, message));
 
-    public bool TryDequeueMessage(out (string id, string message) message)
-    {
-        lock (_newMessagesLock)
-        {
-            return _newMessages.TryDequeue(out message);
-        }
-    }
+    public ChannelReader<(string Id, string Message)> Messages => _messages.Reader;
 
     public IReadOnlyList<IPlayerSession> GetServerClients(ServerType serverType)
     {
@@ -159,7 +147,10 @@ public class SharedState
                 continue;
 
             if (existing is PlayerSession playerSession)
+            {
+                UnregisterClient(serverType, playerSession.ConnectionId);
                 playerSession.ClientConnection.Dispose();
+            }
         }
     }
 

--- a/AISpace.Common/PacketDispatcher.cs
+++ b/AISpace.Common/PacketDispatcher.cs
@@ -32,7 +32,7 @@ public sealed class PacketDispatcher
         }
 
         using var scope = _scopeFactory.CreateScope();
-        var handler = (IPacketHandler)ActivatorUtilities.CreateInstance(scope.ServiceProvider, handlerType);
+        var handler = (IPacketHandler)scope.ServiceProvider.GetRequiredService(handlerType);
         if (handler is IRequiresAuthenticatedSession && !session.IsAuthenticated)
         {
             _logger.LogWarning("Rejecting unauthenticated packet {ServerType}:{PacketType} from client {ClientId}", ServerType, type, session.ConnectionId);

--- a/AISpace.Network/ClientConnection.cs
+++ b/AISpace.Network/ClientConnection.cs
@@ -21,7 +21,17 @@ public class ClientConnection(Guid _Id, EndPoint _RemoteEndPoint, NetworkStream 
     public NetworkStream Stream = _ns;
     public DateTimeOffset Connected { get; } = DateTimeOffset.UtcNow;
 
-    public async Task SendRawAsync(byte[] data, CancellationToken ct = default) => await Stream.WriteAsync(data, ct);
+    private int _closed;
+
+    public bool IsClosed => Volatile.Read(ref _closed) != 0;
+
+    public async Task SendRawAsync(byte[] data, CancellationToken ct = default)
+    {
+        if (IsClosed)
+            return;
+
+        await Stream.WriteAsync(data, ct);
+    }
 
     public void SetCamelliaKeys(byte[] s2cKey, byte[] c2sKey)
     {
@@ -55,6 +65,9 @@ public class ClientConnection(Guid _Id, EndPoint _RemoteEndPoint, NetworkStream 
 
     public async Task SendAsync(PacketType type, byte[] payload, CancellationToken ct = default)
     {
+        if (IsClosed)
+            return;
+
         if (type != PacketType.Ping && type != PacketType.TimeZoneGetResponse)
             logger.LogInformation("Sending: {type}, {len}", type, payload.Length);
         try
@@ -86,6 +99,10 @@ public class ClientConnection(Guid _Id, EndPoint _RemoteEndPoint, NetworkStream 
                 offset += plainChunkSize;
             }
         }
+        catch (ObjectDisposedException)
+        {
+            // connection closed while a fire-and-forget send was in flight
+        }
         catch (Exception ex)
         {
             logger.LogError("Err {ex}", ex);
@@ -104,6 +121,9 @@ public class ClientConnection(Guid _Id, EndPoint _RemoteEndPoint, NetworkStream 
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+            return;
+
         try
         {
             Stream.Dispose();

--- a/AISpace.Server.Tests/GameServerHealthRegistryTests.cs
+++ b/AISpace.Server.Tests/GameServerHealthRegistryTests.cs
@@ -19,6 +19,31 @@ public class GameServerHealthRegistryTests
         );
 
     [Fact]
+    public void RecordHeartbeat_WhenServerNotRegistered_DoesNotCreateEntry()
+    {
+        var registry = CreateRegistry();
+
+        registry.RecordHeartbeat(ServerType.Auth);
+
+        Assert.Empty(registry.GetSnapshot());
+    }
+
+    [Fact]
+    public void RecordHeartbeatsForRegisteredServers_OnlyUpdatesRegisteredServers()
+    {
+        var registry = CreateRegistry();
+        registry.AddServer(ServerType.Msg, 50052);
+        registry.MarkListening(ServerType.Msg, 50052);
+
+        registry.RecordHeartbeatsForRegisteredServers();
+
+        var snapshot = registry.GetSnapshot();
+        Assert.Single(snapshot);
+        Assert.Equal("healthy", snapshot["msgServer"].State);
+        Assert.NotNull(snapshot["msgServer"].LastHeartbeatUtc);
+    }
+
+    [Fact]
     public void MarkListening_WithFreshHeartbeat_IsHealthy()
     {
         var registry = CreateRegistry();

--- a/AISpace.Server/AreaServer.cs
+++ b/AISpace.Server/AreaServer.cs
@@ -1,29 +1,9 @@
 using AISpace.Common;
 using AISpace.Common.Game;
-using AISpace.Network;
-using AISpace.Network.Packets.Area;
 
 namespace AISpace.Server;
 
 public class AreaServer(ILogger<AreaServer> logger, GameServerContext ctx, int port) : GameServerBase<AreaServer>(logger, ctx, port)
 {
     protected override ServerType ActiveServerType => ServerType.Area;
-
-    protected override TimeSpan? GameLoopInterval => TimeSpan.FromSeconds(1);
-
-    protected override void OnTick(CancellationToken ct) => BroadcastServerTime();
-
-    private void BroadcastServerTime()
-    {
-        var t = TimeZoneService.GetServerTime();
-
-        var timePacket = new TimeZoneGetResponse(0, (uint)t.Phase, t.Current, t.Max, 0);
-        byte[] data = timePacket.ToBytes();
-
-        foreach (var client in State.GetServerClients(ServerType.Area))
-        {
-            if (client.IsAuthenticated)
-                _ = client.SendAsync(PacketType.TimeZoneGetResponse, data);
-        }
-    }
 }

--- a/AISpace.Server/AreaServer.cs
+++ b/AISpace.Server/AreaServer.cs
@@ -8,26 +8,22 @@ namespace AISpace.Server;
 public class AreaServer(ILogger<AreaServer> logger, GameServerContext ctx, int port) : GameServerBase<AreaServer>(logger, ctx, port)
 {
     protected override ServerType ActiveServerType => ServerType.Area;
-    private DateTime _nextTimeUpdate = DateTime.MinValue;
 
-    protected override void OnTick(CancellationToken ct) => UpdateWorld();
+    protected override TimeSpan? GameLoopInterval => TimeSpan.FromSeconds(1);
 
-    private void UpdateWorld()
+    protected override void OnTick(CancellationToken ct) => BroadcastServerTime();
+
+    private void BroadcastServerTime()
     {
-        if (DateTime.UtcNow > _nextTimeUpdate)
+        var t = TimeZoneService.GetServerTime();
+
+        var timePacket = new TimeZoneGetResponse(0, (uint)t.Phase, t.Current, t.Max, 0);
+        byte[] data = timePacket.ToBytes();
+
+        foreach (var client in State.GetServerClients(ServerType.Area))
         {
-            var t = TimeZoneService.GetServerTime();
-
-            var timePacket = new TimeZoneGetResponse(0, (uint)t.Phase, t.Current, t.Max, 0);
-            byte[] data = timePacket.ToBytes();
-
-            foreach (var client in State.GetServerClients(ServerType.Area))
-            {
-                if (client.IsAuthenticated)
-                    _ = client.SendAsync(PacketType.TimeZoneGetResponse, data);
-            }
-
-            _nextTimeUpdate = DateTime.UtcNow.AddSeconds(1);
+            if (client.IsAuthenticated)
+                _ = client.SendAsync(PacketType.TimeZoneGetResponse, data);
         }
     }
 }

--- a/AISpace.Server/AuthServer.cs
+++ b/AISpace.Server/AuthServer.cs
@@ -19,9 +19,4 @@ public class AuthServer(ILogger<AuthServer> logger, GameServerContext ctx, int p
         if (!await db.Users.AnyAsync(ct))
             await userRepo.AddAsync("testuser", "password");
     }
-
-    protected override void OnTick(CancellationToken ct)
-    {
-        //Clear expired sessions
-    }
 }

--- a/AISpace.Server/GameServerBase.cs
+++ b/AISpace.Server/GameServerBase.cs
@@ -129,11 +129,15 @@ public abstract class GameServerBase<T> : BackgroundService
         }
     }
 
+    /// <summary>When null, no periodic game loop runs. Override to enable <see cref="OnTick"/>.</summary>
+    protected virtual TimeSpan? GameLoopInterval => null;
+
     private async Task RunGameLoop(CancellationToken ct)
     {
         try
         {
-            using var timer = new PeriodicTimer(TickRate);
+            var interval = GameLoopInterval ?? HealthRegistry.HeartbeatInterval;
+            using var timer = new PeriodicTimer(interval);
             while (await timer.WaitForNextTickAsync(ct))
             {
                 try
@@ -145,7 +149,8 @@ public abstract class GameServerBase<T> : BackgroundService
                         _lastHeartbeatUtc = now;
                     }
 
-                    OnTick(ct);
+                    if (GameLoopInterval is not null)
+                        OnTick(ct);
                 }
                 catch (OperationCanceledException)
                 {

--- a/AISpace.Server/GameServerBase.cs
+++ b/AISpace.Server/GameServerBase.cs
@@ -15,7 +15,6 @@ public abstract class GameServerBase<T> : BackgroundService
     protected readonly IServiceScopeFactory ScopeFactory;
     protected readonly int _port;
     protected readonly ILoggerFactory _loggerFactory;
-    protected readonly TimeSpan TickRate;
 
     protected abstract ServerType ActiveServerType { get; }
 
@@ -26,7 +25,6 @@ public abstract class GameServerBase<T> : BackgroundService
     private readonly int _clientReadTimeoutSeconds;
     private readonly int _packetChannelCapacity;
     private bool _initialized;
-    private DateTime _lastHeartbeatUtc = DateTime.MinValue;
 
     protected GameServerBase(ILogger<T> logger, GameServerContext ctx, int port)
     {
@@ -41,11 +39,12 @@ public abstract class GameServerBase<T> : BackgroundService
         _maxReceiveFrameSize = ctx.MaxReceiveFrameSize;
         _clientReadTimeoutSeconds = ctx.ClientReadTimeoutSeconds;
         _packetChannelCapacity = ctx.PacketChannelCapacity;
-        TickRate = TimeSpan.FromMilliseconds(1000.0 / Math.Max(1, ctx.TickRateHz));
         HealthRegistry.AddServer(ActiveServerType, _port);
     }
 
     protected virtual Task InitializeAsync(CancellationToken ct) => Task.CompletedTask;
+
+    protected virtual IEnumerable<Task> GetAdditionalLoops(CancellationToken ct) => [];
 
     protected override async Task ExecuteAsync(CancellationToken ct)
     {
@@ -76,24 +75,32 @@ public abstract class GameServerBase<T> : BackgroundService
 
             var acceptLoop = listener.RunAsync(runToken);
             var packetLoop = RunPacketLoop(channel.Reader, runToken);
-            var gameLoop = RunGameLoop(runToken);
+            var additionalLoops = GetAdditionalLoops(runToken).ToArray();
 
-            var completed = await Task.WhenAny(acceptLoop, packetLoop);
+            var allLoops = new List<Task>(2 + additionalLoops.Length) { acceptLoop, packetLoop };
+            allLoops.AddRange(additionalLoops);
+
+            var completed = await Task.WhenAny(allLoops);
             if (completed == acceptLoop)
             {
                 Logger.LogWarning("{ServerType} TCP listener stopped unexpectedly; restarting", ActiveServerType);
                 HealthRegistry.MarkUnhealthy(ActiveServerType, "tcp listener stopped");
             }
-            else
+            else if (completed == packetLoop)
             {
                 Logger.LogWarning("{ServerType} packet loop stopped unexpectedly; restarting listener", ActiveServerType);
                 HealthRegistry.MarkUnhealthy(ActiveServerType, "packet loop stopped");
+            }
+            else
+            {
+                Logger.LogWarning("{ServerType} auxiliary loop stopped unexpectedly; restarting listener", ActiveServerType);
+                HealthRegistry.MarkUnhealthy(ActiveServerType, "auxiliary loop stopped");
             }
 
             runCts.Cancel();
             HealthRegistry.ClearAcceptCheck(ActiveServerType);
             HealthRegistry.ClearClientLoadCheck(ActiveServerType);
-            await Task.WhenAll(acceptLoop.ContinueWith(_ => Task.CompletedTask, TaskScheduler.Default), packetLoop.ContinueWith(_ => Task.CompletedTask, TaskScheduler.Default), gameLoop.ContinueWith(_ => Task.CompletedTask, TaskScheduler.Default));
+            await Task.WhenAll(allLoops.Select(task => task.ContinueWith(_ => Task.CompletedTask, TaskScheduler.Default)));
 
             if (ct.IsCancellationRequested)
                 break;
@@ -128,45 +135,4 @@ public abstract class GameServerBase<T> : BackgroundService
             // expected during listener restart
         }
     }
-
-    /// <summary>When null, no periodic game loop runs. Override to enable <see cref="OnTick"/>.</summary>
-    protected virtual TimeSpan? GameLoopInterval => null;
-
-    private async Task RunGameLoop(CancellationToken ct)
-    {
-        try
-        {
-            var interval = GameLoopInterval ?? HealthRegistry.HeartbeatInterval;
-            using var timer = new PeriodicTimer(interval);
-            while (await timer.WaitForNextTickAsync(ct))
-            {
-                try
-                {
-                    var now = DateTime.UtcNow;
-                    if (now - _lastHeartbeatUtc >= HealthRegistry.HeartbeatInterval)
-                    {
-                        HealthRegistry.RecordHeartbeat(ActiveServerType);
-                        _lastHeartbeatUtc = now;
-                    }
-
-                    if (GameLoopInterval is not null)
-                        OnTick(ct);
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Game tick failed (ServerType={ServerType}): {Message}", ActiveServerType, ex.Message);
-                }
-            }
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // expected during listener restart
-        }
-    }
-
-    protected virtual void OnTick(CancellationToken ct) { }
 }

--- a/AISpace.Server/GameServerContext.cs
+++ b/AISpace.Server/GameServerContext.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace AISpace.Server;
 
-public sealed record GameServerContext(ILoggerFactory LoggerFactory, IServiceScopeFactory ScopeFactory, PacketDispatcher Dispatcher, SharedState State, GameServerHealthRegistry HealthRegistry, int MaxConcurrentClients, int PacketChannelCapacity, int MaxReceiveFrameSize, int ClientReadTimeoutSeconds, int TickRateHz)
+public sealed record GameServerContext(ILoggerFactory LoggerFactory, IServiceScopeFactory ScopeFactory, PacketDispatcher Dispatcher, SharedState State, GameServerHealthRegistry HealthRegistry, int MaxConcurrentClients, int PacketChannelCapacity, int MaxReceiveFrameSize, int ClientReadTimeoutSeconds)
 {
-    public static GameServerContext Create(IServiceProvider services, int maxConcurrentClients, int packetChannelCapacity, int maxReceiveFrameSize, int clientReadTimeoutSeconds, int tickRateHz) =>
-        new(services.GetRequiredService<ILoggerFactory>(), services.GetRequiredService<IServiceScopeFactory>(), services.GetRequiredService<PacketDispatcher>(), services.GetRequiredService<SharedState>(), services.GetRequiredService<GameServerHealthRegistry>(), maxConcurrentClients, packetChannelCapacity, maxReceiveFrameSize, clientReadTimeoutSeconds, tickRateHz);
+    public static GameServerContext Create(IServiceProvider services, int maxConcurrentClients, int packetChannelCapacity, int maxReceiveFrameSize, int clientReadTimeoutSeconds) =>
+        new(services.GetRequiredService<ILoggerFactory>(), services.GetRequiredService<IServiceScopeFactory>(), services.GetRequiredService<PacketDispatcher>(), services.GetRequiredService<SharedState>(), services.GetRequiredService<GameServerHealthRegistry>(), maxConcurrentClients, packetChannelCapacity, maxReceiveFrameSize, clientReadTimeoutSeconds);
 }

--- a/AISpace.Server/GameServerHealthRegistry.cs
+++ b/AISpace.Server/GameServerHealthRegistry.cs
@@ -41,9 +41,19 @@ public sealed class GameServerHealthRegistry
 
     public void RecordHeartbeat(ServerType serverType)
     {
-        var now = DateTime.UtcNow;
-        _entries.AddOrUpdate(serverType, _ => new ServerHealthEntry(ToDisplayName(serverType), 0, "healthy", null, now, now), (_, existing) => existing with { LastHeartbeatUtc = now });
+        if (!_entries.TryGetValue(serverType, out var existing))
+            return;
+
+        _entries[serverType] = existing with { LastHeartbeatUtc = DateTime.UtcNow };
     }
+
+    public void RecordHeartbeatsForRegisteredServers()
+    {
+        foreach (var serverType in _entries.Keys)
+            RecordHeartbeat(serverType);
+    }
+
+    public bool IsRegistered(ServerType serverType) => _entries.ContainsKey(serverType);
 
     public void SetAcceptCheck(ServerType serverType, Func<bool> isAccepting)
     {

--- a/AISpace.Server/MsgServer.cs
+++ b/AISpace.Server/MsgServer.cs
@@ -7,6 +7,8 @@ public class MsgServer(ILogger<MsgServer> logger, GameServerContext ctx, int por
 {
     protected override ServerType ActiveServerType => ServerType.Msg;
 
+    protected override TimeSpan? GameLoopInterval => TickRate;
+
     protected override void OnTick(CancellationToken ct)
     {
         while (State.TryDequeueMessage(out var message))

--- a/AISpace.Server/MsgServer.cs
+++ b/AISpace.Server/MsgServer.cs
@@ -7,14 +7,18 @@ public class MsgServer(ILogger<MsgServer> logger, GameServerContext ctx, int por
 {
     protected override ServerType ActiveServerType => ServerType.Msg;
 
-    protected override TimeSpan? GameLoopInterval => TickRate;
+    protected override IEnumerable<Task> GetAdditionalLoops(CancellationToken ct) => [RunMessageLoop(ct)];
 
-    protected override void OnTick(CancellationToken ct)
+    private async Task RunMessageLoop(CancellationToken ct)
     {
-        while (State.TryDequeueMessage(out var message))
+        try
         {
-            Logger.LogInformation("{id} sent {message}", message.id, message.message);
-            // Send message to all other users
+            await foreach (var (id, message) in State.Messages.ReadAllAsync(ct))
+                Logger.LogInformation("{id} sent {message}", id, message);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // expected during listener restart
         }
     }
 }

--- a/AISpace.Server/Program.cs
+++ b/AISpace.Server/Program.cs
@@ -26,7 +26,14 @@ internal class Program
 {
     static async Task Main(string[] args)
     {
-        var builder = WebApplication.CreateBuilder(args);
+        // appsettings.json is copied next to the DLL; use that path so config loads regardless of cwd (e.g. dotnet run from repo root).
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions
+            {
+                Args = args,
+                ContentRootPath = AppContext.BaseDirectory,
+            }
+        );
         // Sdk.Web auto-binds Kestrel:Endpoints from appsettings; FrameworkReference-only projects do not.
         builder.WebHost.ConfigureKestrel((context, serverOptions) => serverOptions.Configure(context.Configuration.GetSection("Kestrel")));
         // IP override: set Server__IPOverride (e.g. Server__IPOverride=host.docker.internal) or IP_OVERRIDE env to replace localhost addresses in Docker.
@@ -107,6 +114,10 @@ internal class Program
         builder.Services.AddHostedService<ScheduledMaintenanceService>();
 
         var app = builder.Build();
+
+        var configuredApiKey = app.Services.GetRequiredService<IOptions<ApiSettings>>().Value.ApiKey;
+        if (string.IsNullOrEmpty(configuredApiKey))
+            app.Logger.LogWarning("ApiSettings:ApiKey is not configured; /api routes will return 401 until a key is set (appsettings or ApiSettings__ApiKey)");
 
         app.UseApiKeyAuthForApiRoutes();
         app.MapAispaceHttpEndpoints();

--- a/AISpace.Server/Program.cs
+++ b/AISpace.Server/Program.cs
@@ -27,13 +27,7 @@ internal class Program
     static async Task Main(string[] args)
     {
         // appsettings.json is copied next to the DLL; use that path so config loads regardless of cwd (e.g. dotnet run from repo root).
-        var builder = WebApplication.CreateBuilder(
-            new WebApplicationOptions
-            {
-                Args = args,
-                ContentRootPath = AppContext.BaseDirectory,
-            }
-        );
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = args, ContentRootPath = AppContext.BaseDirectory });
         // Sdk.Web auto-binds Kestrel:Endpoints from appsettings; FrameworkReference-only projects do not.
         builder.WebHost.ConfigureKestrel((context, serverOptions) => serverOptions.Configure(context.Configuration.GetSection("Kestrel")));
         // IP override: set Server__IPOverride (e.g. Server__IPOverride=host.docker.internal) or IP_OVERRIDE env to replace localhost addresses in Docker.
@@ -45,7 +39,7 @@ internal class Program
         builder.Logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Information);
         builder.Logging.AddNLog();
 
-        builder.Services.Configure<ServerOptions>(builder.Configuration.GetSection("Server"));
+        builder.Services.AddOptions<ServerOptions>().Bind(builder.Configuration.GetSection("Server"));
         builder.Services.AddDbContext<MainContext>((sp, options) => sp.GetRequiredService<IOptions<ServerOptions>>().Value.DbOptions.ConfigureDbContext(options));
         builder.Services.AddDbContextFactory<MainContext>((sp, options) => sp.GetRequiredService<IOptions<ServerOptions>>().Value.DbOptions.ConfigureDbContext(options));
 
@@ -78,11 +72,11 @@ internal class Program
             return new SharedState(sessionStore, sessionClientRegistry, pendingTransitionStore);
         });
         // Add all IPacketHandler classsess
-        builder.Services.Scan(scan => scan.FromAssemblyOf<IPacketHandler>().AddClasses(classes => classes.AssignableTo<IPacketHandler>()).AsImplementedInterfaces().WithScopedLifetime());
+        builder.Services.Scan(scan => scan.FromAssemblyOf<IPacketHandler>().AddClasses(classes => classes.AssignableTo<IPacketHandler>()).AsImplementedInterfaces().AsSelf().WithScopedLifetime());
 
         builder.Services.AddSingleton<PacketDispatcher>();
-        builder.Services.Configure<MaintenanceOptions>(builder.Configuration.GetSection("Maintenance"));
-        builder.Services.Configure<ApiSettings>(builder.Configuration.GetSection("ApiSettings"));
+        builder.Services.AddOptions<MaintenanceOptions>().Bind(builder.Configuration.GetSection("Maintenance"));
+        builder.Services.AddOptions<ApiSettings>().Bind(builder.Configuration.GetSection("ApiSettings"));
         builder.Services.AddSingleton<BroadcastService>();
         builder.Services.AddScoped<UserAdminService>();
         builder.Services.AddSingleton<GameServerHealthRegistry>();
@@ -99,7 +93,7 @@ internal class Program
         GameServerContext BuildGameServerContext(IServiceProvider sp)
         {
             var o = sp.GetRequiredService<IOptions<ServerOptions>>().Value;
-            return GameServerContext.Create(sp, o.MaxConcurrentClients, o.PacketChannelCapacity, o.MaxReceiveFrameSize, o.ClientReadTimeoutSeconds, o.TickRateHz);
+            return GameServerContext.Create(sp, o.MaxConcurrentClients, o.PacketChannelCapacity, o.MaxReceiveFrameSize, o.ClientReadTimeoutSeconds);
         }
 
         if (authEnabled)
@@ -111,6 +105,7 @@ internal class Program
         if (areaEnabled)
             builder.Services.AddHostedService(sp => ActivatorUtilities.CreateInstance<AreaServer>(sp, BuildGameServerContext(sp), areaPort));
 
+        builder.Services.AddHostedService<GameServerSchedulerService>();
         builder.Services.AddHostedService<ScheduledMaintenanceService>();
 
         var app = builder.Build();

--- a/AISpace.Server/Services/GameServerSchedulerService.cs
+++ b/AISpace.Server/Services/GameServerSchedulerService.cs
@@ -11,8 +11,6 @@ namespace AISpace.Server.Services;
 /// <summary>Single process-wide timer for health heartbeats and area timezone broadcasts.</summary>
 public sealed class GameServerSchedulerService(SharedState state, GameServerHealthRegistry healthRegistry, IOptions<ServerOptions> options, ILogger<GameServerSchedulerService> logger) : BackgroundService
 {
-    private static readonly ServerType[] HeartbeatServers = [ServerType.Auth, ServerType.Msg, ServerType.Area];
-
     protected override async Task ExecuteAsync(CancellationToken ct)
     {
         var heartbeatIntervalSeconds = Math.Max(1, options.Value.HealthCheck.HeartbeatIntervalSeconds);
@@ -24,10 +22,7 @@ public sealed class GameServerSchedulerService(SharedState state, GameServerHeal
         {
             tick++;
             if (tick % heartbeatIntervalSeconds == 0)
-            {
-                foreach (var serverType in HeartbeatServers)
-                    healthRegistry.RecordHeartbeat(serverType);
-            }
+                healthRegistry.RecordHeartbeatsForRegisteredServers();
 
             BroadcastAreaTimeIfNeeded();
         }
@@ -35,6 +30,9 @@ public sealed class GameServerSchedulerService(SharedState state, GameServerHeal
 
     private void BroadcastAreaTimeIfNeeded()
     {
+        if (!healthRegistry.IsRegistered(ServerType.Area))
+            return;
+
         var clients = state.GetServerClients(ServerType.Area);
         if (!clients.Any(client => client.IsAuthenticated))
             return;

--- a/AISpace.Server/Services/GameServerSchedulerService.cs
+++ b/AISpace.Server/Services/GameServerSchedulerService.cs
@@ -1,0 +1,51 @@
+using AISpace.Common;
+using AISpace.Common.Config;
+using AISpace.Common.Game;
+using AISpace.Common.Services;
+using AISpace.Network;
+using AISpace.Network.Packets.Area;
+using Microsoft.Extensions.Options;
+
+namespace AISpace.Server.Services;
+
+/// <summary>Single process-wide timer for health heartbeats and area timezone broadcasts.</summary>
+public sealed class GameServerSchedulerService(SharedState state, GameServerHealthRegistry healthRegistry, IOptions<ServerOptions> options, ILogger<GameServerSchedulerService> logger) : BackgroundService
+{
+    private static readonly ServerType[] HeartbeatServers = [ServerType.Auth, ServerType.Msg, ServerType.Area];
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        var heartbeatIntervalSeconds = Math.Max(1, options.Value.HealthCheck.HeartbeatIntervalSeconds);
+        logger.LogInformation("Game scheduler started (1s tick, heartbeat every {HeartbeatSeconds}s)", heartbeatIntervalSeconds);
+
+        var tick = 0;
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        while (await timer.WaitForNextTickAsync(ct))
+        {
+            tick++;
+            if (tick % heartbeatIntervalSeconds == 0)
+            {
+                foreach (var serverType in HeartbeatServers)
+                    healthRegistry.RecordHeartbeat(serverType);
+            }
+
+            BroadcastAreaTimeIfNeeded();
+        }
+    }
+
+    private void BroadcastAreaTimeIfNeeded()
+    {
+        var clients = state.GetServerClients(ServerType.Area);
+        if (!clients.Any(client => client.IsAuthenticated))
+            return;
+
+        var t = TimeZoneService.GetServerTime();
+        var data = new TimeZoneGetResponse(0, (uint)t.Phase, t.Current, t.Max, 0).ToBytes();
+
+        foreach (var client in clients)
+        {
+            if (client.IsAuthenticated)
+                _ = client.SendAsync(PacketType.TimeZoneGetResponse, data);
+        }
+    }
+}

--- a/AISpace.Server/Services/GameServerSchedulerService.cs
+++ b/AISpace.Server/Services/GameServerSchedulerService.cs
@@ -22,9 +22,25 @@ public sealed class GameServerSchedulerService(SharedState state, GameServerHeal
         {
             tick++;
             if (tick % heartbeatIntervalSeconds == 0)
-                healthRegistry.RecordHeartbeatsForRegisteredServers();
+                RunTickStep("heartbeat", () => healthRegistry.RecordHeartbeatsForRegisteredServers());
 
-            BroadcastAreaTimeIfNeeded();
+            RunTickStep("area time broadcast", BroadcastAreaTimeIfNeeded);
+        }
+    }
+
+    private void RunTickStep(string stepName, Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Game scheduler {StepName} failed: {Message}", stepName, ex.Message);
         }
     }
 

--- a/AISpace.Server/appsettings.json
+++ b/AISpace.Server/appsettings.json
@@ -22,8 +22,8 @@
         "MaxConcurrentClients": 32,
         "MaxReceiveFrameSize": 4096,
         "ClientReadTimeoutSeconds": 300,
-        "TickRateHz": 60,
-        "UseDistributedSessionPresence": true,
+        "TickRateHz": 10,
+        "UseDistributedSessionPresence": false,
         "AuthServer": {
             "Enabled": true,
             "Port": 50050

--- a/AISpace.Server/appsettings.json
+++ b/AISpace.Server/appsettings.json
@@ -22,7 +22,6 @@
         "MaxConcurrentClients": 32,
         "MaxReceiveFrameSize": 4096,
         "ClientReadTimeoutSeconds": 300,
-        "TickRateHz": 10,
         "UseDistributedSessionPresence": false,
         "AuthServer": {
             "Enabled": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - Server__PacketChannelCapacity=512
       - Server__MaxReceiveFrameSize=4096
       - Server__ClientReadTimeoutSeconds=300
-      - Server__TickRateHz=10
       - Server__UseDistributedSessionPresence=false
       - IP_OVERRIDE=host.docker.internal
       - Server__DbOptions__ConnectionString=Data Source=/data/main.db;Cache=Shared;Default Timeout=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - Server__PacketChannelCapacity=512
       - Server__MaxReceiveFrameSize=4096
       - Server__ClientReadTimeoutSeconds=300
-      - Server__TickRateHz=20
+      - Server__TickRateHz=10
       - Server__UseDistributedSessionPresence=false
       - IP_OVERRIDE=host.docker.internal
       - Server__DbOptions__ConnectionString=Data Source=/data/main.db;Cache=Shared;Default Timeout=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - Server__UseDistributedSessionPresence=false
       - IP_OVERRIDE=host.docker.internal
       - Server__DbOptions__ConnectionString=Data Source=/data/main.db;Cache=Shared;Default Timeout=5
+      - ApiSettings__ApiKey=1mQmb9SvUkATRoVLdVEvkmaKbuufQMVH
     volumes:
       - /opt/aisp-data:/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Merges `dev` into `master` with launcher tooling, game content and handler updates, Docker/CI changes, and a set of server reliability and idle-CPU improvements.

### Server performance & scheduling
- Remove the empty Auth `OnTick` loop and lower default tick usage.
- Replace per-server `PeriodicTimer` loops with a single `GameServerSchedulerService` (1s tick) for health heartbeats and area timezone broadcasts (skipped when no authenticated area clients).
- Remove `TickRateHz` from server config; Msg internal messages now use a `Channel` instead of polling.
- `PacketDispatcher` resolves handlers via DI (`AsSelf()` + `GetRequiredService`) instead of `ActivatorUtilities.CreateInstance`.
- `ClientConnection` tracks closed state to avoid send-after-dispose noise; superseded sessions are unregistered before the socket is disposed.

### Configuration & API
- Fix API key not loading when running locally (`ContentRootPath = AppContext.BaseDirectory`, `AddOptions<ApiSettings>().Bind(...)`).
- Startup warning when `ApiSettings:ApiKey` is missing.
- `ApiSettings__ApiKey` set in `docker-compose.yml`.

### Stability & networking
- `VceListener` / `GameServerBase` listener restart loop, read timeouts, and improved health checks (`IsListening`, client load, heartbeat staleness).
- `ClientReadTimeoutSeconds` (default 5 min) to clear stuck sockets.
- SQLite pragma interceptor and memory-related server options.

### Game content & handlers
- Map / map-link seed expansion, `Island` on maps, direct map-link transitions, `/tp` and `/jump` chat commands.
- `ItemGetBaseListHandler` response caching (~1.8MB payload).
- Chat forwarding fixes, avatar move animation fix, circle notify typo fix.

### Launcher & CI
- New `AISpace.Launcher` (Avalonia) with `launcher-release` GitHub Actions workflow (CalVer, win-x64 + linux-x64).
- Docker publish workflow updates; deploy workflow removed.

## Test plan

- [ ] `dotnet build AISpace.sln && dotnet test AISpace.sln`
- [ ] Local server: no `ApiSettings:ApiKey is not configured` warning; `curl -H 'X-Api-Key: …' http://127.0.0.1:8080/api/servers/clients` returns JSON
- [ ] Idle CPU on VPS/Docker is lower than before (no per-server 10–60 Hz loops)
- [ ] Login → Auth / Msg / Area flow works; timezone updates still reach area clients
- [ ] `/healthz` reports healthy while servers are listening
- [ ] Launcher builds and connects on Windows/Linux
- [ ] Docker image builds and starts with `docker compose up`