### PR TITLE
Fix enter_areasv_r failure reply size

### DIFF
--- a/aisp.Common/Handlers/Area/AreasvEnterHandler.cs
+++ b/aisp.Common/Handlers/Area/AreasvEnterHandler.cs
@@ -39,9 +39,11 @@ public class AreasvEnterHandler(
 
         if (userSession is null || userSession.UserId != loginReq.UserID)
         {
+            // recv_enter_areasv_r is a fixed 8-byte read on the client (result + objId);
+            // a 4-byte body desyncs the record parser.
             await session.SendAsync(
                 ResponseType,
-                new LoginResponse(AuthResponseResult.InvalidCredentials).ToBytes(),
+                new AreasvEnterResponse((uint)AuthResponseResult.InvalidCredentials, 0).ToBytes(),
                 ct
             );
             return;
@@ -51,7 +53,7 @@ public class AreasvEnterHandler(
         {
             await session.SendAsync(
                 ResponseType,
-                new LoginResponse(AuthResponseResult.AccountBanned).ToBytes(),
+                new AreasvEnterResponse((uint)AuthResponseResult.AccountBanned, 0).ToBytes(),
                 ct
             );
             return;

--- a/docs/PacketLayout/PacketDataAuth.md
+++ b/docs/PacketLayout/PacketDataAuth.md
@@ -36,7 +36,7 @@
 - **Direction:** ServerToClient
 - **Packet ID (hex):** 0xB6B4
 - **Packet ID (int):** 46772
-- **Packet Size:** 12
+- **Packet Size:** 16
 - **Description:** Response to client version check; returns result and server version.
 
 **Layout:**
@@ -125,7 +125,7 @@
 - **Direction:** ClientToServer
 - **Packet ID (hex):** 0x62BC
 - **Packet ID (int):** 25276
-- **Packet Size:** 12
+- **Packet Size:** 16
 - **Description:** Client sends client version for compatibility check.
 
 **Layout:**

--- a/tests/aisp.Common.Tests/AreaMapHandlersTests.cs
+++ b/tests/aisp.Common.Tests/AreaMapHandlersTests.cs
@@ -2916,6 +2916,44 @@ public class AreaMapHandlersTests
         };
     }
 
+    [Fact]
+    public async Task AreasvEnterHandler_InvalidOtp_SendsEightByteEnterResponse()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+
+        try
+        {
+            var session = new CapturingPlayerSession();
+            await using var handlerDb = new MainContext(options);
+            var handler = new AreasvEnterHandler(
+                new UserSessionRepository(handlerDb, NullLogger<UserSessionRepository>.Instance),
+                new MapRepository(handlerDb),
+                new ChannelRepository(handlerDb),
+                new CharacterRepository(handlerDb, NullLogger<CharacterRepository>.Instance),
+                new MyRoomRepository(handlerDb),
+                new CircleRepository(handlerDb),
+                new FriendRepository(handlerDb),
+                new SharedState(),
+                NullLogger<AreasvEnterHandler>.Instance
+            );
+
+            await handler.HandleAsync(
+                BuildAreasvEnterPayload(1, "unknown-otp-12345678"),
+                session,
+                TestContext.Current.CancellationToken
+            );
+
+            // recv_enter_areasv_r is a fixed 8-byte read on the client (result + objId).
+            var reply = Assert.Single(session.Sent, p => p.Type == PacketType.AreasvEnterResponse);
+            Assert.Equal(8, reply.Payload.Length);
+            Assert.NotEqual(0u, new PacketReader(reply.Payload).ReadUInt());
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
     private static User CreateUserWithCharacter(
         int userId,
         int characterId,


### PR DESCRIPTION
```
  Fixed build (8-byte reply)

  AreasvEnterRequest
  Sending AreasvEnterResponse, 8
  Recieving AreasvLeaveRequest        (+55 ms)
  Area Client disconnected
  Msg Client disconnected

  The client parsed the result, answered with areasv_leave, and tore both connections down itself.

  Unfixed build (4-byte reply)

  AreasvEnterRequest
  Sending AreasvEnterResponse, 4
  Area Client disconnected            (no areasv_leave)
  Recieving [Msg] LogoutRequest
  Msg Client disconnected
  
  The Area socket just drops, then the client runs its generic "back to title" logout through the Msg server.
```