### PR TITLE
Screen control

### DIFF
--- a/aisp.Common/Config/NicoLiveOptions.cs
+++ b/aisp.Common/Config/NicoLiveOptions.cs
@@ -4,6 +4,7 @@ public sealed class NicoLiveOptions
 {
     /// <summary>
     /// Live-program ID sent to maps containing Nico Live billboard surfaces. An empty value disables playback.
+    /// "lv1" is a dummy placeholder, not a real programme; set to an actual lv&lt;digits&gt; id to enable it.
     /// </summary>
     public string LiveId { get; set; } = "lv1";
 }

--- a/aisp.Common/DAL/Entities/Nicotv.cs
+++ b/aisp.Common/DAL/Entities/Nicotv.cs
@@ -11,8 +11,11 @@ public sealed class Nicotv
     public uint ChannelId { get; set; }
     public string MovieId { get; set; } = "";
     public NicotvPlaybackState PlaybackState { get; set; } = NicotvPlaybackState.Closed;
-    public NicotvCommentVisibility CommentVisibility { get; set; } =
-        NicotvCommentVisibility.Visible;
+
+    // The server's own default for the TV's comment overlay, not the client's: the client has no
+    // request for it and its TV panel sends every snapshot as comments visible. Off unless a
+    // moderator turns it on for a TV. The page reads it from its title when served.
+    public NicotvCommentVisibility CommentVisibility { get; set; } = NicotvCommentVisibility.Hidden;
     public DateTime UpdatedAt { get; set; }
 
     public MyRoomFurniture Furniture { get; set; } = default!;

--- a/aisp.Common/DAL/MainContext.cs
+++ b/aisp.Common/DAL/MainContext.cs
@@ -162,6 +162,11 @@ public class MainContext(DbContextOptions<MainContext> options) : DbContext(opti
             e.Property(x => x.PlaybackState)
                 .HasConversion<uint>()
                 .HasDefaultValue(NicotvPlaybackState.Closed);
+            // TODO: make Hidden the database default too (a migration altering this column's
+            // default) once the screens branch lands; kept out of it so it merges without a schema
+            // change. New rows already get Hidden from the entity's initializer, which EF writes
+            // explicitly since it differs from the enum's zero; this only costs a startup warning
+            // about the mismatch.
             e.Property(x => x.CommentVisibility)
                 .HasConversion<uint>()
                 .HasDefaultValue(NicotvCommentVisibility.Visible);

--- a/aisp.Common/DAL/Repositories/NicotvRepository.cs
+++ b/aisp.Common/DAL/Repositories/NicotvRepository.cs
@@ -20,6 +20,7 @@ public interface INicotvRepository
     );
     Task<Nicotv?> GetByIdInRoomAsync(int roomId, uint nicotvId, CancellationToken ct = default);
     Task<Nicotv?> GetByIdAsync(uint nicotvId, CancellationToken ct = default);
+    Task<IReadOnlyList<Nicotv>> GetByChannelAsync(uint channelId, CancellationToken ct = default);
     Task<Nicotv?> SetChannelAsync(
         int roomId,
         uint nicotvId,
@@ -119,6 +120,12 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
 
         return await db.Nicotvs.SingleOrDefaultAsync(x => x.Id == checked((int)nicotvId), ct);
     }
+
+    public async Task<IReadOnlyList<Nicotv>> GetByChannelAsync(
+        uint channelId,
+        CancellationToken ct = default
+    ) =>
+        channelId == 0 ? [] : await db.Nicotvs.Where(x => x.ChannelId == channelId).ToListAsync(ct);
 
     public async Task<Nicotv?> SetChannelAsync(
         int roomId,

--- a/aisp.Common/DAL/Repositories/NicotvRepository.cs
+++ b/aisp.Common/DAL/Repositories/NicotvRepository.cs
@@ -145,6 +145,9 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
         // channel clears it, and re-entering the room shows the tuned channel.
         nicotv.ChannelId = channelId;
         nicotv.MovieId = "";
+        // Tuning implies the TV is on: the client shows the channel at once and sends no open
+        // for it (open/close is the power toggle alone), so the stored state follows.
+        nicotv.PlaybackState = NicotvPlaybackState.Playing;
         nicotv.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync(ct);
         return nicotv;
@@ -187,6 +190,8 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
         // Exclusive with a channel selection; see the matching note in SetChannelAsync.
         nicotv.MovieId = movieId;
         nicotv.ChannelId = 0;
+        // Same as SetChannelAsync: setting a movie turns the TV on and starts it playing.
+        nicotv.PlaybackState = NicotvPlaybackState.Playing;
         nicotv.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync(ct);
         return nicotv;

--- a/aisp.Common/DAL/Repositories/NicotvRepository.cs
+++ b/aisp.Common/DAL/Repositories/NicotvRepository.cs
@@ -122,7 +122,11 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
         if (nicotv is null)
             return null;
 
+        // A TV shows a channel or a typed movie, never both. The movie id takes precedence when
+        // resolving what a TV shows (a typed video is the more specific pick), so tuning a
+        // channel clears it, and re-entering the room shows the tuned channel.
         nicotv.ChannelId = channelId;
+        nicotv.MovieId = "";
         nicotv.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync(ct);
         return nicotv;
@@ -162,7 +166,9 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
         if (nicotv is null)
             return null;
 
+        // Exclusive with a channel selection; see the matching note in SetChannelAsync.
         nicotv.MovieId = movieId;
+        nicotv.ChannelId = 0;
         nicotv.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync(ct);
         return nicotv;

--- a/aisp.Common/DAL/Repositories/NicotvRepository.cs
+++ b/aisp.Common/DAL/Repositories/NicotvRepository.cs
@@ -19,6 +19,7 @@ public interface INicotvRepository
         CancellationToken ct = default
     );
     Task<Nicotv?> GetByIdInRoomAsync(int roomId, uint nicotvId, CancellationToken ct = default);
+    Task<Nicotv?> GetByIdAsync(uint nicotvId, CancellationToken ct = default);
     Task<Nicotv?> SetChannelAsync(
         int roomId,
         uint nicotvId,
@@ -109,6 +110,14 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
             x => x.RoomId == roomId && x.Id == checked((int)nicotvId),
             ct
         );
+    }
+
+    public async Task<Nicotv?> GetByIdAsync(uint nicotvId, CancellationToken ct = default)
+    {
+        if (nicotvId == 0 || nicotvId > int.MaxValue)
+            return null;
+
+        return await db.Nicotvs.SingleOrDefaultAsync(x => x.Id == checked((int)nicotvId), ct);
     }
 
     public async Task<Nicotv?> SetChannelAsync(

--- a/aisp.Common/DAL/Repositories/NicotvRepository.cs
+++ b/aisp.Common/DAL/Repositories/NicotvRepository.cs
@@ -92,7 +92,9 @@ public sealed class NicotvRepository(MainContext db) : INicotvRepository
         nicotv.ChannelId = data.ChannelId;
         nicotv.MovieId = data.MovieId;
         nicotv.PlaybackState = data.PlaybackState;
-        nicotv.CommentVisibility = data.CommentVisibility;
+        // Not CommentVisibility: the client's TV panel fills that field with a constant (visible)
+        // in every snapshot it sends, so it says nothing about what the TV shows. The stored value
+        // is the server's default for the TV (see Nicotv.CommentVisibility).
         nicotv.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync(ct);
         return nicotv;

--- a/aisp.Common/Game/NicotvMapper.cs
+++ b/aisp.Common/Game/NicotvMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using aisp.Common.DAL.Entities;
 using aisp.Network.Data;
 
@@ -6,5 +7,26 @@ namespace aisp.Common.Game;
 internal static class NicotvMapper
 {
     public static NicotvData ToPacket(Nicotv nicotv) =>
-        new(nicotv.ChannelId, nicotv.MovieId, nicotv.PlaybackState, nicotv.CommentVisibility);
+        new(
+            nicotv.ChannelId,
+            WithNicotvId(nicotv.MovieId, checked((uint)nicotv.Id)),
+            nicotv.PlaybackState,
+            nicotv.CommentVisibility
+        );
+
+    /// <summary>
+    /// Appends the furniture's own database id as an n: tag (movieId's whole content when it is
+    /// empty), so wherever this reaches the screen page's movieid= it round-trips: the server
+    /// then keys the shared timeline, and resolves content, by this specific TV rather than by
+    /// map and channel, which do not reliably tell one player's room from another's. Short (n:,
+    /// not nicotvid:) since it is invisible wire budget inside a 96-character movie id, not
+    /// something read by a person. Falls back to the plain movie id on an implausibly long typed
+    /// string rather than exceed that limit.
+    /// </summary>
+    public static string WithNicotvId(string movieId, uint nicotvId)
+    {
+        var tag = "n:" + nicotvId.ToString(CultureInfo.InvariantCulture);
+        var tagged = movieId.Length == 0 ? tag : $"{movieId} {tag}";
+        return tagged.Length <= NicotvData.MovieIdLength - 1 ? tagged : movieId;
+    }
 }

--- a/aisp.Common/Game/NicotvMapper.cs
+++ b/aisp.Common/Game/NicotvMapper.cs
@@ -20,8 +20,9 @@ internal static class NicotvMapper
     /// then keys the shared timeline, and resolves content, by this specific TV rather than by
     /// map and channel, which do not reliably tell one player's room from another's. Short (n:,
     /// not nicotvid:) since it is invisible wire budget inside a 96-character movie id, not
-    /// something read by a person. Falls back to the plain movie id on an implausibly long typed
-    /// string rather than exceed that limit.
+    /// something read by a person. Not tvid:, which is the client's own word for a channel number
+    /// (see ScreenAssignments.IsChannelSource), an unrelated thing. Falls back to the plain movie
+    /// id on an implausibly long typed string rather than exceed that limit.
     /// </summary>
     public static string WithNicotvId(string movieId, uint nicotvId)
     {

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -24,14 +24,52 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     private readonly TimeProvider _time = time ?? TimeProvider.System;
     private readonly ConcurrentDictionary<uint, Entry> _byMap = new();
 
-    // Timelines of videos typed into room TVs, by map and channel: room instances share a map
-    // id, so the channel the hook adds to the TV's URL is what tells one room from another.
+    // Timelines of videos typed into room TVs, by the furniture's own database id where known
+    // (see the n: tag below), or by map and channel otherwise: room instances share a map id,
+    // and the channel the hook adds to the TV's URL is not reliably one room's own (it is the
+    // player's session slot, not the room), so that id is what actually distinguishes rooms.
     private readonly ConcurrentDictionary<string, Timeline> _byMovie = new(
         StringComparer.OrdinalIgnoreCase
     );
 
     private static string MovieKey(uint map, int channel, string movieId) =>
         string.Create(CultureInfo.InvariantCulture, $"{map}/{channel}/{movieId}");
+
+    private static string NicotvKey(uint nicotvId) =>
+        string.Create(CultureInfo.InvariantCulture, $"nicotv:{nicotvId}");
+
+    /// <summary>
+    /// n:&lt;id&gt;: the Nicotv furniture's own database id, carried as a tag on a room TV's
+    /// movie id so the shared timeline can be keyed by the specific TV rather than by map
+    /// and channel, which do not reliably identify a room (see <see cref="_byMovie"/>). Short
+    /// (not nicotvid:) since it is invisible wire budget inside a 96-character movie id, not
+    /// something read by a person.
+    /// </summary>
+    public static bool TryGetNicotvId(string? source, out uint nicotvId)
+    {
+        nicotvId = 0;
+        if (source is null)
+            return false;
+        foreach (var word in ExtrasOf(source))
+            if (
+                word.StartsWith("n:", StringComparison.OrdinalIgnoreCase)
+                && uint.TryParse(
+                    word.AsSpan(2),
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out nicotvId
+                )
+            )
+                return true;
+        return false;
+    }
+
+    /// <summary>The room-tv timeline key for a (possibly n:-tagged) movie id: the furniture's
+    /// own id when present, otherwise the map-and-channel fallback.</summary>
+    private static string RoomTvKey(uint map, int channel, string movieId) =>
+        TryGetNicotvId(movieId, out var nicotvId)
+            ? NicotvKey(nicotvId)
+            : MovieKey(map, channel, MainOf(movieId));
 
     /// <summary>
     /// Where a video is: at <see cref="StartedAt"/> it was at <see cref="Offset"/> seconds and
@@ -84,7 +122,7 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     {
         if (!IsVideoSource(movieId))
             return false;
-        var key = MovieKey(map, channel, MainOf(movieId));
+        var key = RoomTvKey(map, channel, movieId);
         var timeline = _byMovie.GetOrAdd(key, _ => new Timeline(_time.GetUtcNow(), 0, null));
         var updated = Apply(timeline, action);
         if (updated is null)
@@ -102,11 +140,7 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     {
         if (!IsVideoSource(movieId))
             return;
-        _byMovie[MovieKey(map, channel, MainOf(movieId))] = new Timeline(
-            _time.GetUtcNow(),
-            0,
-            null
-        );
+        _byMovie[RoomTvKey(map, channel, movieId)] = new Timeline(_time.GetUtcNow(), 0, null);
     }
 
     private Timeline? Apply(Timeline timeline, string action)
@@ -634,7 +668,7 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
             {
                 // A typed video plays from a timeline shared by that TV, in that room.
                 var timeline = _byMovie.GetOrAdd(
-                    MovieKey(mapId ?? 0, channel, typed),
+                    RoomTvKey(mapId ?? 0, channel, movieId),
                     _ => new Timeline(_time.GetUtcNow(), 0, null)
                 );
                 return ToHookSource(typed) + " " + TimelineWords(timeline);

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -83,7 +83,10 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         nicotvId = 0;
         if (source is null)
             return false;
-        foreach (var word in ExtrasOf(source))
+        // Every word, the first included: a TV with no typed movie carries the tag alone (see
+        // NicotvMapper.WithNicotvId), and that is the movieid= its client comes back with after a
+        // power cycle, when its stored channel is all the server has to go on.
+        foreach (var word in Normalize(source).Split(' '))
             if (
                 word.StartsWith("n:", StringComparison.OrdinalIgnoreCase)
                 && uint.TryParse(

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -60,14 +60,14 @@ public sealed class ScreenAssignments
     /// Canonical form of a source: trimmed, with the typed short ids expanded to their prefixed
     /// forms (tw: to twitch:, a bare lv… id to nico:, bare pattern to pattern:live). A source is
     /// "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
-    /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]]":
-    /// main:&lt;url&gt; is a frame page under the main panel, with the box relative to that
-    /// panel; banner:&lt;url&gt; is a page for the Stage banner strip (the title card when
-    /// absent); a bare page URL is the raw form, a frame page under the whole crop with a box or
-    /// key word, the banner otherwise; a box word places the video inside the crop; a crop word
-    /// renders the picture at another size and shows the box-sized window at cx,cy of it (for
-    /// browser sources sw/sh is the layout viewport); scroll words pan a browser document;
-    /// scale:N is browser zoom; a key word colour-keys the video into the page.
+    /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]] [fps:N]
+    /// [rolloff:…] [pan]": main:&lt;url&gt; is a frame page under the main panel, with the box
+    /// relative to that panel; banner:&lt;url&gt; is a page for the Stage banner strip (the
+    /// title card when absent); a bare page URL is the raw form, a frame page under the whole
+    /// crop with a box or key word, the banner otherwise; a box word places the video inside
+    /// the crop; a crop word renders the picture at another size and shows the box-sized window
+    /// at cx,cy of it (for browser sources sw/sh is the layout viewport); scroll words pan a
+    /// browser document; scale:N is browser zoom; a key word colour-keys the video into the page.
     /// </summary>
     public static string Normalize(string source)
     {
@@ -102,6 +102,114 @@ public sealed class ScreenAssignments
                 && word[4..].All(char.IsAsciiHexDigit)
             )
         );
+
+    /// <summary>
+    /// rolloff:near/far (range only, the map's own screen position), rolloff:near/far/max/min
+    /// (also the gains to fade between), rolloff:x/y/z/near/far, rolloff:x/y/z/near/far/max/min,
+    /// or rolloff:flat (flat volume). max is the gain at near or closer and min the gain at far
+    /// or beyond, so the <see cref="DefaultMax"/>/<see cref="DefaultMin"/> default is the plain
+    /// fade to silence and e.g. 1/0.3 keeps a screen audible across the map. The hook attenuates
+    /// and pans the stream from the player's own position; town screens get a default from
+    /// <see cref="ScreenPositions"/> when no word is given.
+    /// </summary>
+    public static bool IsRolloffWord(string? word) =>
+        word is not null
+        && word.StartsWith("rolloff:", StringComparison.OrdinalIgnoreCase)
+        && (
+            string.Equals(word, "rolloff:flat", StringComparison.OrdinalIgnoreCase)
+            || (
+                word[8..].Split('/') is { Length: 2 or 4 or 5 or 7 } parts
+                && parts.All(part =>
+                    double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out _)
+                )
+            )
+        );
+
+    /// <summary>
+    /// The hook wants the seven-number form: fills in the map's screen position for the forms
+    /// that leave it out and <see cref="DefaultMax"/>/<see cref="DefaultMin"/> for the forms that
+    /// leave the gains out. Drops rolloff:flat, or a position-less word on a map without a screen.
+    /// </summary>
+    private static string? ExpandRolloffWord(string word, uint? mapId)
+    {
+        if (string.Equals(word, "rolloff:flat", StringComparison.OrdinalIgnoreCase))
+            return null;
+        var parts = word[8..].Split('/');
+        // 5 and 7 carry the position; 2 and 4 take the map's own screen, and have nowhere to
+        // fall back to without one.
+        var positioned = parts.Length is 5 or 7;
+        string position;
+        if (positioned)
+            position = $"{parts[0]}/{parts[1]}/{parts[2]}";
+        else if (mapId is { } map && ScreenPositions.TryGetValue(map, out var p))
+            position = string.Create(CultureInfo.InvariantCulture, $"{p.X}/{p.Y}/{p.Z}");
+        else
+            return null;
+        var range = positioned ? $"{parts[3]}/{parts[4]}" : $"{parts[0]}/{parts[1]}";
+        // 4 and 7 carry the gains; the other two fade all the way to silence.
+        var gains = parts.Length switch
+        {
+            4 => $"{parts[2]}/{parts[3]}",
+            7 => $"{parts[5]}/{parts[6]}",
+            _ => string.Create(CultureInfo.InvariantCulture, $"{DefaultMax}/{DefaultMin}"),
+        };
+        return $"rolloff:{position}/{range}/{gains}";
+    }
+
+    /// <summary>
+    /// World positions of the town screens, from the client's screen table (one record per map;
+    /// maps with several screens list the first). Room TVs have no fixed position. Same units and
+    /// axes as the avatar position the client reports in move packets (and reads from its own
+    /// CChara transform for the launcher hook's rolloff), so the distance is plain Euclidean.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<uint, (float X, float Y, float Z)> ScreenPositions =
+        new Dictionary<uint, (float, float, float)>
+        {
+            [10990100] = (-17340f, 375f, -20639f),
+            [10990110] = (-16850f, 310f, -19840f),
+            [10990200] = (-10873f, 1202.5f, -997f),
+            [10990210] = (-10873f, 1202.5f, -997f),
+            [10990220] = (-10873f, 1202.5f, -997f),
+            [19001003] = (0f, 352.1f, 1567f),
+            [10010200] = (-32.6f, 497f, -2086.4f),
+            [10010210] = (-32.6f, 497f, -2086.4f),
+            [10020200] = (-32.6f, 497f, -2086.4f),
+            [10020210] = (-32.6f, 497f, -2086.4f),
+            [10030200] = (-32.6f, 497f, -2086.4f),
+            [10030210] = (-32.6f, 497f, -2086.4f),
+            [10010110] = (-11826f, 150f, -4350f),
+            [10990400] = (-239.6f, 274.5f, 1184.8f),
+        };
+
+    /// <summary>Default rolloff, in world units: full volume up to Near, silent from Far.</summary>
+    public const float DefaultNear = 1000f;
+    public const float DefaultFar = 12000f;
+
+    /// <summary>Default gains to fade between: full at Near or closer, silent at Far or beyond.</summary>
+    public const float DefaultMax = 1f;
+    public const float DefaultMin = 0f;
+
+    /// <summary>The rolloff word for a town screen's map, or null for maps without a known screen.</summary>
+    public static string? DefaultRolloffWord(uint mapId) =>
+        ScreenPositions.TryGetValue(mapId, out var p)
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $"rolloff:{p.X}/{p.Y}/{p.Z}/{DefaultNear}/{DefaultFar}/{DefaultMax}/{DefaultMin}"
+            )
+            : null;
+
+    /// <summary>fps:N, the constant rate ffmpeg produces: 15, 20, 25, 30, 50 or 60 (the rates
+    /// that divide both common sample rates, so the audio clock maps to whole frames).</summary>
+    public static bool IsFpsWord(string? word) =>
+        word is not null
+        && word.StartsWith("fps:", StringComparison.OrdinalIgnoreCase)
+        && int.TryParse(word[4..], out var fps)
+        && fps is 15 or 20 or 25 or 30 or 50 or 60;
+
+    /// <summary>pan: stereo-pan the stream by its bearing from the player. Off by default; a
+    /// screen in a street is not a point source, so only the distance rolloff applies.</summary>
+    public static bool IsPanWord(string? word) =>
+        string.Equals(word, "pan", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>scale:N for browser sources: Electron's zoom (1 = 100%), 0.1–8. A texture stretch this is not.</summary>
     public static bool IsScaleWord(string? word) =>
@@ -273,7 +381,7 @@ public sealed class ScreenAssignments
     /// <summary>
     /// What /screen accepts: a stream, a page, blank, the title card, the test page, the
     /// calibration aids; with optional extras (main:, banner: and bare page URLs, box, crop, key,
-    /// scroll and scale words).
+    /// fps, rolloff, pan, scroll and scale words).
     /// </summary>
     public static bool IsValidSource(string? source)
     {
@@ -289,6 +397,9 @@ public sealed class ScreenAssignments
                     || IsBoxWord(word)
                     || IsCropWord(word)
                     || IsKeyWord(word)
+                    || IsFpsWord(word)
+                    || IsRolloffWord(word)
+                    || IsPanWord(word)
                     || IsScrollWord(word)
                     || IsScaleWord(word)
                 )
@@ -356,6 +467,26 @@ public sealed class ScreenAssignments
             return route == "room-tv" ? Blank : TitleCard;
         if (string.Equals(source, TestScreen, StringComparison.OrdinalIgnoreCase))
             return null;
-        return ToHookSource(source);
+        // Town screens attenuate with distance by default; an explicit rolloff word wins, filled
+        // out to the hook's seven-number form; rolloff:flat drops it.
+        var words = ToHookSource(source).Split(' ').ToList();
+        var rolloffIndex = words.FindIndex(IsRolloffWord);
+        if (rolloffIndex >= 0)
+        {
+            var expanded = ExpandRolloffWord(words[rolloffIndex], mapId);
+            if (expanded is null)
+                words.RemoveAt(rolloffIndex);
+            else
+                words[rolloffIndex] = expanded;
+        }
+        else if (
+            IsStreamSource(source)
+            && mapId is { } m2
+            && DefaultRolloffWord(m2) is { } defaultRolloff
+        )
+        {
+            words.Add(defaultRolloff);
+        }
+        return string.Join(' ', words);
     }
 }

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -580,19 +580,20 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         uint.Parse(MainOf(source).AsSpan(8), NumberStyles.None, CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// What /channel accepts for a channel's content: a bare stream, not a video with a shared
-    /// timeline (channels are livestream-only, with no per-channel pause/resume/seek) and not
-    /// another channel (no indirection chains). A channel is purely a source map: no box, key,
-    /// main:, crop: or other framing extras here; those belong on whoever references the
-    /// channel (a room TV typing channel:&lt;n&gt;, or /screen channel:&lt;n&gt; box:... key
-    /// main:...), since different screens frame the same channel differently. See
+    /// What /channel accepts for a channel's content: a bare stream or a web page, not a video
+    /// with a shared timeline (channels are livestream-only, with no per-channel
+    /// pause/resume/seek) and not another channel (no indirection chains). A channel is purely a
+    /// source map: no box, key, main:, crop: or other framing extras here; those belong on
+    /// whoever references the channel (a room TV typing channel:&lt;n&gt;, or /screen
+    /// channel:&lt;n&gt; box:... key main:...), since different screens frame the same channel
+    /// differently. See
     /// <see cref="ResolveChannelIndirection"/>, which keeps the reference's own extras and drops
     /// the channel's word for its main token alone.
     /// </summary>
     public static bool IsValidChannelContentSource(string? source) =>
         source is not null
         && !ExtrasOf(source).Any()
-        && IsStreamSource(source)
+        && (IsStreamSource(source) || IsPageUrl(source))
         && !IsVideoSource(source)
         && !IsChannelSource(source);
 

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -1,0 +1,251 @@
+using System.Collections.Concurrent;
+
+namespace aisp.Common.Game;
+
+/// <summary>
+/// What the in-game screens on a map should play. The client's town displays (the Akihabara
+/// screen, the Stage billboard) and room TVs are IE controls that load a page from the emulator
+/// (see ScreenEndpointsExtensions); the page tells the launcher's hook what to stream by
+/// publishing a source in its title, and this is where that source comes from. One source per
+/// map, set with the /screen chat command.
+///
+/// The ids anyone may type into a room TV (fetched by every viewer's client, so only short ids
+/// that expand to a known site): title, pattern:live, tw:&lt;channel&gt; (Twitch through
+/// streamlink), twe:&lt;channel&gt; (the Twitch player embed in the off-screen browser),
+/// ytl:&lt;id&gt; (a YouTube live through streamlink) and lv… (Nico Live through streamlink).
+/// Only /screen takes streamlink:&lt;url&gt;, stream:&lt;url&gt;, electron:&lt;url&gt; and a
+/// web page URL.
+/// </summary>
+public sealed class ScreenAssignments
+{
+    private readonly ConcurrentDictionary<uint, string> _byMap = new();
+
+    public void Set(uint mapId, string source) => _byMap[mapId] = Normalize(source);
+
+    /// <summary>An empty main area.</summary>
+    public const string Blank = "blank";
+
+    /// <summary>The diagnostic page itself, whatever the map is set to.</summary>
+    public const string TestScreen = "testscreen";
+
+    /// <summary>A plain title card, "aisp-emu" on a dark background: the default look for a display.</summary>
+    public const string TitleCard = "title";
+
+    /// <summary>The diagnostic page with a fine coordinate grid, for measuring screen panels.</summary>
+    public const string Calibrate = "calibrate";
+
+    /// <summary>
+    /// The launcher hook's own calibration picture and test tone, generated in the client at the
+    /// panel's exact size. pattern:live counts from zero whenever it starts, like a stream. Bare
+    /// "pattern" is the same thing.
+    /// </summary>
+    public const string PatternLive = "pattern:live";
+
+    /// <summary>
+    /// The parent Twitch's player embed demands: it must name the site embedding the player.
+    /// The off-screen browser loads the player page top-level, so the value only has to exist.
+    /// </summary>
+    public const string TwitchEmbedParent = "aisp.moe";
+
+    /// <summary>
+    /// The map with the Nico Live billboard (seedData/maps.json: "Stage"). notify_nicolive_reload
+    /// only does anything there (confirmed on the shopping mall, which has none): the client has
+    /// nothing on other maps that reacts to it, so sending it elsewhere is a silent no-op.
+    /// CmdExecHandler scopes its send to this map.
+    /// </summary>
+    public const uint StageMapId = 19_001_003;
+
+    /// <summary>
+    /// Canonical form of a source: trimmed, with the typed short ids expanded to their prefixed
+    /// forms (tw: to twitch:, a bare lv… id to nico:, bare pattern to pattern:live).
+    /// </summary>
+    public static string Normalize(string source)
+    {
+        var words = source.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+            return "";
+        var main = words[0];
+        if (main.StartsWith("tw:", StringComparison.OrdinalIgnoreCase))
+            main = "twitch:" + main[3..];
+        else if (IsNicoLiveId(main))
+            main = "nico:" + main;
+        else if (string.Equals(main, "pattern", StringComparison.OrdinalIgnoreCase))
+            main = PatternLive;
+        else if (string.Equals(main, PatternLive, StringComparison.OrdinalIgnoreCase))
+            main = main.ToLowerInvariant();
+        return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
+    }
+
+    private static string MainOf(string source) => Normalize(source).Split(' ')[0];
+
+    private static IEnumerable<string> ExtrasOf(string source) =>
+        Normalize(source).Split(' ').Skip(1);
+
+    public bool Clear(uint mapId) => _byMap.TryRemove(mapId, out _);
+
+    public string? Get(uint mapId) => _byMap.TryGetValue(mapId, out var source) ? source : null;
+
+    // The ids end up inside URLs on every viewer's command line (streamlink, the browser host),
+    // so only the characters the sites themselves use are let through.
+
+    /// <summary>A Twitch login: letters, digits and underscores.</summary>
+    public static bool IsTwitchChannel(string? value) =>
+        value is { Length: > 0 and <= 32 }
+        && value.All(c => char.IsAsciiLetterOrDigit(c) || c == '_');
+
+    /// <summary>A YouTube video id: letters, digits, '-' and '_'.</summary>
+    public static bool IsYouTubeId(string? value) =>
+        value is { Length: > 0 and <= 64 }
+        && value.All(c => char.IsAsciiLetterOrDigit(c) || c == '-' || c == '_');
+
+    /// <summary>lv followed by digits: a Nico Live programme id, as typed into a TV.</summary>
+    public static bool IsNicoLiveId(string? value) =>
+        value is not null
+        && value.Length > 2
+        && value.StartsWith("lv", StringComparison.OrdinalIgnoreCase)
+        && value[2..].All(char.IsAsciiDigit);
+
+    private static bool HasPrefix(string main, string prefix, Func<string, bool> rest) =>
+        main.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && rest(main[prefix.Length..]);
+
+    /// <summary>twitch:&lt;channel&gt; (tw: for short): a Twitch live stream through streamlink.</summary>
+    public static bool IsTwitchSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "twitch:", IsTwitchChannel);
+
+    /// <summary>twe:&lt;channel&gt;: the Twitch player embed in the off-screen browser.</summary>
+    public static bool IsTwitchEmbedSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "twe:", IsTwitchChannel);
+
+    /// <summary>nico:lv… (a bare lv… id): a Nico Live programme through streamlink.</summary>
+    public static bool IsNicoLiveSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoLiveId);
+
+    /// <summary>ytl:&lt;id&gt;: a YouTube live stream through streamlink.</summary>
+    public static bool IsYouTubeLiveSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "ytl:", IsYouTubeId);
+
+    /// <summary>pattern:live, the hook's own test picture and tone.</summary>
+    public static bool IsPatternSource(string? source) =>
+        source is not null
+        && string.Equals(MainOf(source), PatternLive, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// electron:&lt;http(s) url&gt;: any page in the off-screen browser, overlaid like a stream.
+    /// Only from /screen; a typed room TV id would make every viewer's client fetch the page.
+    /// </summary>
+    public static bool IsElectronSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "electron:", IsPageUrl);
+
+    /// <summary>Sources the off-screen browser shows: electron:&lt;url&gt; and the Twitch embed.</summary>
+    public static bool IsBrowserSource(string? source) =>
+        IsElectronSource(source) || IsTwitchEmbedSource(source);
+
+    /// <summary>
+    /// The ids anyone may type into a room TV: short ids that expand to a known site (or the
+    /// test pattern), never an arbitrary URL, since every viewer's client fetches what is typed.
+    /// </summary>
+    public static bool IsTypedSource(string? source) =>
+        IsTwitchSource(source)
+        || IsTwitchEmbedSource(source)
+        || IsNicoLiveSource(source)
+        || IsYouTubeLiveSource(source)
+        || IsPatternSource(source);
+
+    /// <summary>
+    /// Sources the launcher hook plays: the typed ids, plus (from /screen only)
+    /// streamlink:&lt;url&gt; (any page one of streamlink's plugins handles), stream:&lt;url&gt;
+    /// (an MP4, HLS playlist, anything ffmpeg opens) and electron:&lt;http(s) url&gt;.
+    /// </summary>
+    public static bool IsStreamSource(string? source) =>
+        source is not null
+        && (
+            IsTypedSource(source)
+            || HasPrefix(MainOf(source), "streamlink:", rest => rest.Length > 0)
+            || HasPrefix(MainOf(source), "stream:", rest => rest.Length > 0)
+            || IsElectronSource(source)
+        );
+
+    /// <summary>A web page the screen shows as is, framed inside the screen page.</summary>
+    public static bool IsPageUrl(string? source) =>
+        source is not null
+        && (
+            MainOf(source).StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || MainOf(source).StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+        );
+
+    /// <summary>
+    /// What /screen accepts: a stream, a page, blank, the title card, the test page, the
+    /// calibration aids. A single word: nothing may follow it.
+    /// </summary>
+    public static bool IsValidSource(string? source)
+    {
+        if (source is null)
+            return false;
+        var main = MainOf(source);
+        if (ExtrasOf(source).Any())
+            return false;
+        return IsStreamSource(main)
+            || IsPageUrl(main)
+            || string.Equals(main, Blank, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(main, TitleCard, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(main, TestScreen, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(main, Calibrate, StringComparison.OrdinalIgnoreCase)
+            // c:x1/y1:x2/y2[:x3/y3:x4/y4]... draws those rectangles on the page, for measuring.
+            || main.StartsWith("c:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The form the launcher hook understands: streamlink:&lt;url&gt; (anything streamlink
+    /// opens), stream:&lt;url&gt; (anything ffmpeg opens), pattern:live and
+    /// electron:&lt;http(s) url&gt;; the friendly ids are vocabulary of this server. Page URLs
+    /// and the page's own keywords pass through.
+    /// </summary>
+    public static string ToHookSource(string source)
+    {
+        var words = Normalize(source).Split(' ');
+        var main = words[0];
+        if (IsTwitchSource(main))
+            main = "streamlink:https://twitch.tv/" + main[7..];
+        else if (IsTwitchEmbedSource(main))
+            main =
+                "electron:https://player.twitch.tv/?channel="
+                + main[4..]
+                + "&parent="
+                + TwitchEmbedParent;
+        else if (IsNicoLiveSource(main))
+            main = "streamlink:https://live.nicovideo.jp/watch/" + main[5..];
+        else if (IsYouTubeLiveSource(main))
+            main = "streamlink:https://www.youtube.com/watch?v=" + main[4..];
+        return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
+    }
+
+    /// <summary>
+    /// The source a screen page should publish, given the route the hook sent the client to,
+    /// the movie id (room TVs only) and the map the hook read from the client. Null means the
+    /// page shows its diagnostics. A typed movie id only reaches this for the typed ids
+    /// (<see cref="IsTypedSource"/>), the title card, the test page and the calibration grid:
+    /// anything else typed (the c: rectangles included) falls back to the map's assignment. An
+    /// unassigned room TV stays blank; an unassigned town screen shows the title card.
+    /// </summary>
+    public string? Resolve(string route, string? movieId, uint? mapId)
+    {
+        if (route == "room-tv" && movieId is not null)
+        {
+            var typed = MainOf(movieId);
+            if (string.Equals(typed, TestScreen, StringComparison.OrdinalIgnoreCase))
+                return null;
+            if (string.Equals(typed, TitleCard, StringComparison.OrdinalIgnoreCase))
+                return TitleCard;
+            if (string.Equals(typed, Calibrate, StringComparison.OrdinalIgnoreCase))
+                return Calibrate;
+            if (IsTypedSource(typed))
+                return ToHookSource(typed);
+        }
+        var source = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
+        if (source is null)
+            return route == "room-tv" ? Blank : TitleCard;
+        if (string.Equals(source, TestScreen, StringComparison.OrdinalIgnoreCase))
+            return null;
+        return ToHookSource(source);
+    }
+}

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -11,17 +11,129 @@ namespace aisp.Common.Game;
 /// map, set with the /screen chat command.
 ///
 /// The ids anyone may type into a room TV (fetched by every viewer's client, so only short ids
-/// that expand to a known site): title, pattern:live, tw:&lt;channel&gt; (Twitch through
-/// streamlink), twe:&lt;channel&gt; (the Twitch player embed in the off-screen browser),
-/// ytl:&lt;id&gt; (a YouTube live through streamlink) and lv… (Nico Live through streamlink).
+/// that expand to a known site): title, pattern:live, pattern:vod, tw:&lt;channel&gt; (Twitch
+/// through streamlink), twe:&lt;channel&gt; (the Twitch player embed in the off-screen browser),
+/// yt:&lt;id&gt; (a YouTube video through yt-dlp), ytl:&lt;id&gt; (a YouTube live through
+/// streamlink), lv… (Nico Live through streamlink), lv…:vod (the same, once archived, as a
+/// video through yt-dlp instead) and sm… (a Nico video through yt-dlp).
 /// Only /screen takes streamlink:&lt;url&gt;, stream:&lt;url&gt;, electron:&lt;url&gt; and a
 /// web page URL.
 /// </summary>
-public sealed class ScreenAssignments
+public sealed class ScreenAssignments(TimeProvider? time = null)
 {
-    private readonly ConcurrentDictionary<uint, string> _byMap = new();
+    private readonly TimeProvider _time = time ?? TimeProvider.System;
+    private readonly ConcurrentDictionary<uint, Entry> _byMap = new();
 
-    public void Set(uint mapId, string source) => _byMap[mapId] = Normalize(source);
+    // Timelines of videos typed into room TVs, by map and channel: room instances share a map
+    // id, so the channel the hook adds to the TV's URL is what tells one room from another.
+    private readonly ConcurrentDictionary<string, Timeline> _byMovie = new(
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    private static string MovieKey(uint map, int channel, string movieId) =>
+        string.Create(CultureInfo.InvariantCulture, $"{map}/{channel}/{movieId}");
+
+    /// <summary>
+    /// Where a video is: at <see cref="StartedAt"/> it was at <see cref="Offset"/> seconds and
+    /// playing, unless <see cref="PausedAt"/> is set, in which case it has sat at the position
+    /// it reached then. Every client computes the same position from the same numbers, so all
+    /// screens show the same point of the video; the page publishes them for the hook, which
+    /// seeks accordingly and holds while paused.
+    /// </summary>
+    public sealed record Timeline(DateTimeOffset StartedAt, double Offset, DateTimeOffset? PausedAt)
+    {
+        public bool Paused => PausedAt is not null;
+
+        public double PositionAt(DateTimeOffset now) =>
+            Math.Max(0, Offset + ((PausedAt ?? now) - StartedAt).TotalSeconds);
+
+        public Timeline Pause(DateTimeOffset now) => Paused ? this : this with { PausedAt = now };
+
+        public Timeline Resume(DateTimeOffset now) =>
+            Paused ? new Timeline(now, PositionAt(now), null) : this;
+
+        public Timeline Seek(DateTimeOffset now, double seconds) =>
+            new(now, Math.Max(0, seconds), Paused ? now : null);
+    }
+
+    private sealed record Entry(string Source, Timeline Timeline);
+
+    public void Set(uint mapId, string source) =>
+        _byMap[mapId] = new Entry(Normalize(source), new Timeline(_time.GetUtcNow(), 0, null));
+
+    public Timeline? GetTimeline(uint mapId) =>
+        _byMap.TryGetValue(mapId, out var entry) ? entry.Timeline : null;
+
+    /// <summary>pause, resume or seek:&lt;seconds&gt; on the map's video; false without one.</summary>
+    public bool Control(uint mapId, string action)
+    {
+        if (!_byMap.TryGetValue(mapId, out var entry) || !IsVideoSource(entry.Source))
+            return false;
+        var updated = Apply(entry.Timeline, action);
+        if (updated is null)
+            return false;
+        _byMap[mapId] = entry with { Timeline = updated };
+        return true;
+    }
+
+    /// <summary>
+    /// The same for a video typed into a room TV (its timeline is shared by everyone on that TV,
+    /// in that room: map plus channel, since room instances reuse the same map id).
+    /// </summary>
+    public bool ControlMovie(uint map, int channel, string movieId, string action)
+    {
+        if (!IsVideoSource(movieId))
+            return false;
+        var key = MovieKey(map, channel, MainOf(movieId));
+        var timeline = _byMovie.GetOrAdd(key, _ => new Timeline(_time.GetUtcNow(), 0, null));
+        var updated = Apply(timeline, action);
+        if (updated is null)
+            return false;
+        _byMovie[key] = updated;
+        return true;
+    }
+
+    /// <summary>
+    /// A room TV was freshly set to a movie: (re)starts that TV's timeline at zero for the room,
+    /// so picking a video plays it from the beginning even if that id was already playing
+    /// somewhere else. A no-op for anything that is not a video (streams, pages, the pattern).
+    /// </summary>
+    public void SetMovie(uint map, int channel, string movieId)
+    {
+        if (!IsVideoSource(movieId))
+            return;
+        _byMovie[MovieKey(map, channel, MainOf(movieId))] = new Timeline(
+            _time.GetUtcNow(),
+            0,
+            null
+        );
+    }
+
+    private Timeline? Apply(Timeline timeline, string action)
+    {
+        var now = _time.GetUtcNow();
+        if (string.Equals(action, "pause", StringComparison.OrdinalIgnoreCase))
+            return timeline.Pause(now);
+        if (string.Equals(action, "resume", StringComparison.OrdinalIgnoreCase))
+            return timeline.Resume(now);
+        if (
+            action.StartsWith("seek:", StringComparison.OrdinalIgnoreCase)
+            && double.TryParse(
+                action[5..],
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var seconds
+            )
+        )
+            return timeline.Seek(now, seconds);
+        return null;
+    }
+
+    private static string TimelineWords(Timeline timeline) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"start:{timeline.StartedAt.ToUnixTimeSeconds()} offset:{timeline.Offset:0.###}"
+        ) + (timeline.Paused ? " paused:" + timeline.PausedAt!.Value.ToUnixTimeSeconds() : "");
 
     /// <summary>An empty main area; used with a banner page on the Stage wall.</summary>
     public const string Blank = "blank";
@@ -37,10 +149,12 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// The launcher hook's own calibration picture and test tone, generated in the client at the
-    /// panel's exact size. pattern:live counts from zero whenever it starts, like a stream. Bare
-    /// "pattern" is the same thing.
+    /// panel's exact size. pattern:live counts from zero whenever it starts, like a stream;
+    /// pattern:vod is a looping video that follows the shared timeline, so pause, resume and
+    /// seek can be checked without a real video. Bare "pattern" is the live one.
     /// </summary>
     public const string PatternLive = "pattern:live";
+    public const string PatternVod = "pattern:vod";
 
     /// <summary>
     /// The parent Twitch's player embed demands: it must name the site embedding the player.
@@ -58,8 +172,8 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// Canonical form of a source: trimmed, with the typed short ids expanded to their prefixed
-    /// forms (tw: to twitch:, a bare lv… id to nico:, bare pattern to pattern:live). A source is
-    /// "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
+    /// forms (tw: to twitch:, a bare lv… or sm… id to nico:, bare pattern to pattern:live). A
+    /// source is "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
     /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]] [fps:N]
     /// [rolloff:…] [pan]": main:&lt;url&gt; is a frame page under the main panel, with the box
     /// relative to that panel; banner:&lt;url&gt; is a page for the Stage banner strip (the
@@ -77,11 +191,14 @@ public sealed class ScreenAssignments
         var main = words[0];
         if (main.StartsWith("tw:", StringComparison.OrdinalIgnoreCase))
             main = "twitch:" + main[3..];
-        else if (IsNicoLiveId(main))
+        else if (IsNicoLiveId(main) || IsNicoVideoId(main) || IsNicoLiveVodId(main))
             main = "nico:" + main;
         else if (string.Equals(main, "pattern", StringComparison.OrdinalIgnoreCase))
             main = PatternLive;
-        else if (string.Equals(main, PatternLive, StringComparison.OrdinalIgnoreCase))
+        else if (
+            string.Equals(main, PatternLive, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(main, PatternVod, StringComparison.OrdinalIgnoreCase)
+        )
             main = main.ToLowerInvariant();
         return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
     }
@@ -280,10 +397,11 @@ public sealed class ScreenAssignments
 
     public bool Clear(uint mapId) => _byMap.TryRemove(mapId, out _);
 
-    public string? Get(uint mapId) => _byMap.TryGetValue(mapId, out var source) ? source : null;
+    public string? Get(uint mapId) =>
+        _byMap.TryGetValue(mapId, out var entry) ? entry.Source : null;
 
-    // The ids end up inside URLs on every viewer's command line (streamlink, the browser host),
-    // so only the characters the sites themselves use are let through.
+    // The ids end up inside URLs on every viewer's command line (streamlink, yt-dlp, the
+    // browser host), so only the characters the sites themselves use are let through.
 
     /// <summary>A Twitch login: letters, digits and underscores.</summary>
     public static bool IsTwitchChannel(string? value) =>
@@ -302,6 +420,23 @@ public sealed class ScreenAssignments
         && value.StartsWith("lv", StringComparison.OrdinalIgnoreCase)
         && value[2..].All(char.IsAsciiDigit);
 
+    /// <summary>sm followed by digits: a Nico video id, as typed into a TV.</summary>
+    public static bool IsNicoVideoId(string? value) =>
+        value is not null
+        && value.Length > 2
+        && value.StartsWith("sm", StringComparison.OrdinalIgnoreCase)
+        && value[2..].All(char.IsAsciiDigit);
+
+    /// <summary>
+    /// A Nico Live id with :vod appended: once a broadcast has ended and Nico has archived it,
+    /// the same watch page also serves it as a plain video, playable through yt-dlp with a
+    /// shared timeline (pause/resume/seek) instead of live through streamlink.
+    /// </summary>
+    public static bool IsNicoLiveVodId(string? value) =>
+        value is not null
+        && value.EndsWith(":vod", StringComparison.OrdinalIgnoreCase)
+        && IsNicoLiveId(value[..^4]);
+
     private static bool HasPrefix(string main, string prefix, Func<string, bool> rest) =>
         main.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && rest(main[prefix.Length..]);
 
@@ -317,14 +452,30 @@ public sealed class ScreenAssignments
     public static bool IsNicoLiveSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "nico:", IsNicoLiveId);
 
+    /// <summary>nico:lv…:vod (see <see cref="IsNicoLiveVodId"/>): the archive through yt-dlp,
+    /// with a shared timeline, instead of live through streamlink.</summary>
+    public static bool IsNicoLiveVodSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoLiveVodId);
+
+    /// <summary>nico:sm… (a bare sm… id): a Nico video through yt-dlp, with a shared timeline.</summary>
+    public static bool IsNicoVideoSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoVideoId);
+
+    /// <summary>yt:&lt;id&gt;: a YouTube video through yt-dlp, with a shared timeline.</summary>
+    public static bool IsYouTubeVideoSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "yt:", IsYouTubeId);
+
     /// <summary>ytl:&lt;id&gt;: a YouTube live stream through streamlink.</summary>
     public static bool IsYouTubeLiveSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "ytl:", IsYouTubeId);
 
-    /// <summary>pattern:live, the hook's own test picture and tone.</summary>
+    /// <summary>pattern:live or pattern:vod, the hook's own test picture and tone.</summary>
     public static bool IsPatternSource(string? source) =>
         source is not null
-        && string.Equals(MainOf(source), PatternLive, StringComparison.OrdinalIgnoreCase);
+        && (
+            string.Equals(MainOf(source), PatternLive, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(MainOf(source), PatternVod, StringComparison.OrdinalIgnoreCase)
+        );
 
     /// <summary>
     /// electron:&lt;http(s) url&gt;: any page in the off-screen browser, overlaid like a stream.
@@ -337,6 +488,17 @@ public sealed class ScreenAssignments
     public static bool IsBrowserSource(string? source) =>
         IsElectronSource(source) || IsTwitchEmbedSource(source);
 
+    /// <summary>A video with a shared timeline (not a live stream): yt:, sm… and pattern:vod.
+    /// The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
+    public static bool IsVideoSource(string? source) =>
+        IsYouTubeVideoSource(source)
+        || IsNicoVideoSource(source)
+        || IsNicoLiveVodSource(source)
+        || (
+            source is not null
+            && string.Equals(MainOf(source), PatternVod, StringComparison.OrdinalIgnoreCase)
+        );
+
     /// <summary>
     /// The ids anyone may type into a room TV: short ids that expand to a known site (or the
     /// test pattern), never an arbitrary URL, since every viewer's client fetches what is typed.
@@ -346,6 +508,7 @@ public sealed class ScreenAssignments
         || IsTwitchEmbedSource(source)
         || IsNicoLiveSource(source)
         || IsYouTubeLiveSource(source)
+        || IsVideoSource(source)
         || IsPatternSource(source);
 
     /// <summary>
@@ -417,9 +580,9 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// The form the launcher hook understands: streamlink:&lt;url&gt; (anything streamlink
-    /// opens), stream:&lt;url&gt; (anything ffmpeg opens), pattern:live and
-    /// electron:&lt;http(s) url&gt;; the friendly ids are vocabulary of this server. Page URLs
-    /// and the page's own keywords pass through.
+    /// opens), stream:&lt;url&gt; (anything ffmpeg opens), yt-dlp:&lt;url&gt; (a video it seeks),
+    /// pattern:live, pattern:vod and electron:&lt;http(s) url&gt;; the friendly ids are
+    /// vocabulary of this server. Page URLs and the page's own keywords pass through.
     /// </summary>
     public static string ToHookSource(string source)
     {
@@ -433,8 +596,14 @@ public sealed class ScreenAssignments
                 + main[4..]
                 + "&parent="
                 + TwitchEmbedParent;
+        else if (IsNicoLiveVodSource(main))
+            main = "yt-dlp:https://www.nicovideo.jp/watch/" + main[5..^4];
         else if (IsNicoLiveSource(main))
             main = "streamlink:https://live.nicovideo.jp/watch/" + main[5..];
+        else if (IsNicoVideoSource(main))
+            main = "yt-dlp:https://www.nicovideo.jp/watch/" + main[5..];
+        else if (IsYouTubeVideoSource(main))
+            main = "yt-dlp:https://www.youtube.com/watch?v=" + main[3..];
         else if (IsYouTubeLiveSource(main))
             main = "streamlink:https://www.youtube.com/watch?v=" + main[4..];
         return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
@@ -442,13 +611,15 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// The source a screen page should publish, given the route the hook sent the client to,
-    /// the movie id (room TVs only) and the map the hook read from the client. Null means the
-    /// page shows its diagnostics. A typed movie id only reaches this for the typed ids
-    /// (<see cref="IsTypedSource"/>), the title card, the test page and the calibration grid:
-    /// anything else typed (the c: rectangles included) falls back to the map's assignment. An
-    /// unassigned room TV stays blank; an unassigned town screen shows the title card.
+    /// the movie id (room TVs only), the map the hook read from the client and, for a room TV,
+    /// the channel that tells its room instance apart from another one on the same map. Null
+    /// means the page shows its diagnostics. A typed movie id only reaches this for the typed
+    /// ids (<see cref="IsTypedSource"/>), the title card, the test page and the calibration
+    /// grid: anything else typed (the c: rectangles included) falls back to the map's
+    /// assignment. An unassigned room TV stays blank; an unassigned town screen shows the title
+    /// card.
     /// </summary>
-    public string? Resolve(string route, string? movieId, uint? mapId)
+    public string? Resolve(string route, string? movieId, uint? mapId, int channel = 0)
     {
         if (route == "room-tv" && movieId is not null)
         {
@@ -459,17 +630,27 @@ public sealed class ScreenAssignments
                 return TitleCard;
             if (string.Equals(typed, Calibrate, StringComparison.OrdinalIgnoreCase))
                 return Calibrate;
+            if (IsVideoSource(typed))
+            {
+                // A typed video plays from a timeline shared by that TV, in that room.
+                var timeline = _byMovie.GetOrAdd(
+                    MovieKey(mapId ?? 0, channel, typed),
+                    _ => new Timeline(_time.GetUtcNow(), 0, null)
+                );
+                return ToHookSource(typed) + " " + TimelineWords(timeline);
+            }
             if (IsTypedSource(typed))
                 return ToHookSource(typed);
         }
-        var source = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
-        if (source is null)
+        var entry = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
+        if (entry is null)
             return route == "room-tv" ? Blank : TitleCard;
-        if (string.Equals(source, TestScreen, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(entry.Source, TestScreen, StringComparison.OrdinalIgnoreCase))
             return null;
+        var assigned = entry.Source;
         // Town screens attenuate with distance by default; an explicit rolloff word wins, filled
         // out to the hook's seven-number form; rolloff:flat drops it.
-        var words = ToHookSource(source).Split(' ').ToList();
+        var words = ToHookSource(assigned).Split(' ').ToList();
         var rolloffIndex = words.FindIndex(IsRolloffWord);
         if (rolloffIndex >= 0)
         {
@@ -480,13 +661,15 @@ public sealed class ScreenAssignments
                 words[rolloffIndex] = expanded;
         }
         else if (
-            IsStreamSource(source)
+            IsStreamSource(assigned)
             && mapId is { } m2
             && DefaultRolloffWord(m2) is { } defaultRolloff
         )
         {
             words.Add(defaultRolloff);
         }
+        if (IsVideoSource(assigned))
+            words.Add(TimelineWords(entry.Timeline));
         return string.Join(' ', words);
     }
 }

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 
 namespace aisp.Common.Game;
 
@@ -22,7 +23,7 @@ public sealed class ScreenAssignments
 
     public void Set(uint mapId, string source) => _byMap[mapId] = Normalize(source);
 
-    /// <summary>An empty main area.</summary>
+    /// <summary>An empty main area; used with a banner page on the Stage wall.</summary>
     public const string Blank = "blank";
 
     /// <summary>The diagnostic page itself, whatever the map is set to.</summary>
@@ -57,7 +58,16 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// Canonical form of a source: trimmed, with the typed short ids expanded to their prefixed
-    /// forms (tw: to twitch:, a bare lv… id to nico:, bare pattern to pattern:live).
+    /// forms (tw: to twitch:, a bare lv… id to nico:, bare pattern to pattern:live). A source is
+    /// "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
+    /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]]":
+    /// main:&lt;url&gt; is a frame page under the main panel, with the box relative to that
+    /// panel; banner:&lt;url&gt; is a page for the Stage banner strip (the title card when
+    /// absent); a bare page URL is the raw form, a frame page under the whole crop with a box or
+    /// key word, the banner otherwise; a box word places the video inside the crop; a crop word
+    /// renders the picture at another size and shows the box-sized window at cx,cy of it (for
+    /// browser sources sw/sh is the layout viewport); scroll words pan a browser document;
+    /// scale:N is browser zoom; a key word colour-keys the video into the page.
     /// </summary>
     public static string Normalize(string source)
     {
@@ -75,6 +85,85 @@ public sealed class ScreenAssignments
             main = main.ToLowerInvariant();
         return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
     }
+
+    /// <summary>
+    /// key or key:RRGGBB: colour keying. The page paints the key colour where video belongs and
+    /// the hook fills only those pixels, so HTML can sit over the video. Bare "key" is the
+    /// DirectDraw overlay key of the era, the near-black RGB 16,0,16 (100010) that let a
+    /// rectangle painted in Paint show the movie through.
+    /// </summary>
+    public static bool IsKeyWord(string? word) =>
+        word is not null
+        && (
+            string.Equals(word, "key", StringComparison.OrdinalIgnoreCase)
+            || (
+                word.StartsWith("key:", StringComparison.OrdinalIgnoreCase)
+                && word.Length == 10
+                && word[4..].All(char.IsAsciiHexDigit)
+            )
+        );
+
+    /// <summary>scale:N for browser sources: Electron's zoom (1 = 100%), 0.1–8. A texture stretch this is not.</summary>
+    public static bool IsScaleWord(string? word) =>
+        word is not null
+        && word.StartsWith("scale:", StringComparison.OrdinalIgnoreCase)
+        && double.TryParse(
+            word[6..],
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out var scale
+        )
+        && scale is >= 0.1 and <= 8;
+
+    /// <summary>
+    /// scrollx:N, scrolly:N, or scroll:x/y: document offset in CSS pixels, enforced inside the
+    /// off-screen browser. The layout viewport is crop:sw/sh when given, else the box.
+    /// </summary>
+    public static bool IsScrollWord(string? word)
+    {
+        if (word is null)
+            return false;
+        if (
+            word.StartsWith("scrollx:", StringComparison.OrdinalIgnoreCase)
+            || word.StartsWith("scrolly:", StringComparison.OrdinalIgnoreCase)
+        )
+            return int.TryParse(
+                word[8..],
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out _
+            );
+        return word.StartsWith("scroll:", StringComparison.OrdinalIgnoreCase)
+            && word[7..].Split('/') is { Length: 2 } parts
+            && parts.All(part =>
+                int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out _)
+            );
+    }
+
+    /// <summary>
+    /// box:x/y/w/h with four non-negative integers. Slashes, not commas: the client splits chat
+    /// arguments on commas and spaces (URLs, with their colons and slashes, come through whole).
+    /// </summary>
+    public static bool IsBoxWord(string? word) =>
+        word is not null
+        && word.StartsWith("box:", StringComparison.OrdinalIgnoreCase)
+        && word[4..].Split('/') is { Length: 4 } parts
+        && parts.All(part => int.TryParse(part, out var n) && n >= 0);
+
+    /// <summary>
+    /// crop:sw/sh:cx/cy: the picture is rendered (letterboxed) at sw x sh instead of the box
+    /// size, and the box-sized window starting at cx,cy of that is what the box shows. Zooms
+    /// in, or cuts a region out: crop:972/686:243/171 shows the middle quarter of a TV. For
+    /// browser sources sw x sh is the layout viewport, not a video letterbox.
+    /// </summary>
+    public static bool IsCropWord(string? word) =>
+        word is not null
+        && word.StartsWith("crop:", StringComparison.OrdinalIgnoreCase)
+        && word[5..].Split(':') is { Length: 2 } halves
+        && halves[0].Split('/') is { Length: 2 } size
+        && size.All(part => int.TryParse(part, out var n) && n > 0)
+        && halves[1].Split('/') is { Length: 2 } origin
+        && origin.All(part => int.TryParse(part, out var n) && n >= 0);
 
     private static string MainOf(string source) => Normalize(source).Split(' ')[0];
 
@@ -165,6 +254,14 @@ public sealed class ScreenAssignments
             || IsElectronSource(source)
         );
 
+    /// <summary>main:&lt;url&gt;: a frame page under the main panel; box:x/y/w/h is then relative to it.</summary>
+    public static bool IsMainWord(string? word) =>
+        word is not null && HasPrefix(word, "main:", IsPageUrl);
+
+    /// <summary>banner:&lt;url&gt;: a page for the Stage wall's banner strip.</summary>
+    public static bool IsBannerWord(string? word) =>
+        word is not null && HasPrefix(word, "banner:", IsPageUrl);
+
     /// <summary>A web page the screen shows as is, framed inside the screen page.</summary>
     public static bool IsPageUrl(string? source) =>
         source is not null
@@ -175,14 +272,27 @@ public sealed class ScreenAssignments
 
     /// <summary>
     /// What /screen accepts: a stream, a page, blank, the title card, the test page, the
-    /// calibration aids. A single word: nothing may follow it.
+    /// calibration aids; with optional extras (main:, banner: and bare page URLs, box, crop, key,
+    /// scroll and scale words).
     /// </summary>
     public static bool IsValidSource(string? source)
     {
         if (source is null)
             return false;
         var main = MainOf(source);
-        if (ExtrasOf(source).Any())
+        if (
+            !ExtrasOf(source)
+                .All(word =>
+                    IsPageUrl(word)
+                    || IsMainWord(word)
+                    || IsBannerWord(word)
+                    || IsBoxWord(word)
+                    || IsCropWord(word)
+                    || IsKeyWord(word)
+                    || IsScrollWord(word)
+                    || IsScaleWord(word)
+                )
+        )
             return false;
         return IsStreamSource(main)
             || IsPageUrl(main)

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -28,6 +28,8 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     // (see the n: tag below), or by map and channel otherwise: room instances share a map id,
     // and the channel the hook adds to the TV's URL is not reliably one room's own (it is the
     // player's session slot, not the room), so that id is what actually distinguishes rooms.
+    // Not tvid:, which is the client's own word for a channel number (see IsChannelSource), an
+    // unrelated thing.
     private readonly ConcurrentDictionary<string, Timeline> _byMovie = new(
         StringComparer.OrdinalIgnoreCase
     );
@@ -37,6 +39,37 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
 
     private static string NicotvKey(uint nicotvId) =>
         string.Create(CultureInfo.InvariantCulture, $"nicotv:{nicotvId}");
+
+    // What each numbered "AI channel" currently shows (livestream content only). The client's
+    // channel-screen route names channels in its own tvid= query (it climbs with the channel
+    // number while the NicotvId stays fixed), so the original game apparently modelled these as
+    // shared, reserved fake TVs. The shared-by-number behaviour is kept, backed by a plain
+    // channel map rather than fake furniture rows; channel:<n> is this server's vocabulary for
+    // it, resolved below. tvid= is the client's own word for a channel number, unrelated to the
+    // n: tag (see _byMovie).
+    private readonly ConcurrentDictionary<uint, string> _byChannel = new();
+
+    /// <summary>What channel &lt;n&gt; is currently assigned, or null if nothing is.</summary>
+    public string? GetChannelSource(uint channel) =>
+        _byChannel.TryGetValue(channel, out var source) ? source : null;
+
+    /// <summary>Clears channel &lt;n&gt;'s assignment; true if it had one.</summary>
+    public bool ClearChannelSource(uint channel) => _byChannel.TryRemove(channel, out _);
+
+    /// <summary>Assigns channel &lt;n&gt; a source; see <see cref="IsValidChannelContentSource"/>.</summary>
+    public void SetChannelSource(uint channel, string source) =>
+        _byChannel[channel] = Normalize(source);
+
+    /// <summary>Every map currently bound to channel &lt;n&gt; via channel:&lt;n&gt; (see /channel).</summary>
+    public IReadOnlyList<uint> GetMapsBoundToChannel(uint channel) =>
+        [
+            .. _byMap
+                .Where(entry =>
+                    IsChannelSource(entry.Value.Source)
+                    && ChannelNumberOf(entry.Value.Source) == channel
+                )
+                .Select(entry => entry.Key),
+        ];
 
     /// <summary>
     /// n:&lt;id&gt;: the Nicotv furniture's own database id, carried as a tag on a room TV's
@@ -200,7 +233,7 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     /// The map with the Nico Live billboard (seedData/maps.json: "Stage"). notify_nicolive_reload
     /// only does anything there (confirmed on the shopping mall, which has none): the client has
     /// nothing on other maps that reacts to it, so sending it elsewhere is a silent no-op.
-    /// CmdExecHandler scopes its send to this map.
+    /// CmdExecHandler scopes both its sends (/screen, /channel) to this map.
     /// </summary>
     public const uint StageMapId = 19_001_003;
 
@@ -522,6 +555,47 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     public static bool IsBrowserSource(string? source) =>
         IsElectronSource(source) || IsTwitchEmbedSource(source);
 
+    /// <summary>
+    /// channel:&lt;n&gt;: indirects to whatever /channel assigned channel n (see
+    /// <see cref="_byChannel"/>), resolved in <see cref="Resolve"/> before
+    /// <see cref="ToHookSource"/>. channel:auto indirects to whichever channel the requesting
+    /// screen's own tvid= says it is (a town map's screen may have a fixed one of its own, the
+    /// original game's apparent design; see <see cref="ResolveChannelIndirection"/>), rather
+    /// than a fixed number.
+    /// </summary>
+    public static bool IsChannelSource(string? source) =>
+        source is not null
+        && HasPrefix(
+            MainOf(source),
+            "channel:",
+            rest =>
+                string.Equals(rest, "auto", StringComparison.OrdinalIgnoreCase)
+                || uint.TryParse(rest, NumberStyles.None, CultureInfo.InvariantCulture, out _)
+        );
+
+    private static bool IsAutoChannelWord(string word) =>
+        string.Equals(word, "channel:auto", StringComparison.OrdinalIgnoreCase);
+
+    private static uint ChannelNumberOf(string source) =>
+        uint.Parse(MainOf(source).AsSpan(8), NumberStyles.None, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// What /channel accepts for a channel's content: a bare stream, not a video with a shared
+    /// timeline (channels are livestream-only, with no per-channel pause/resume/seek) and not
+    /// another channel (no indirection chains). A channel is purely a source map: no box, key,
+    /// main:, crop: or other framing extras here; those belong on whoever references the
+    /// channel (a room TV typing channel:&lt;n&gt;, or /screen channel:&lt;n&gt; box:... key
+    /// main:...), since different screens frame the same channel differently. See
+    /// <see cref="ResolveChannelIndirection"/>, which keeps the reference's own extras and drops
+    /// the channel's word for its main token alone.
+    /// </summary>
+    public static bool IsValidChannelContentSource(string? source) =>
+        source is not null
+        && !ExtrasOf(source).Any()
+        && IsStreamSource(source)
+        && !IsVideoSource(source)
+        && !IsChannelSource(source);
+
     /// <summary>A video with a shared timeline (not a live stream): yt:, sm… and pattern:vod.
     /// The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
     public static bool IsVideoSource(string? source) =>
@@ -543,7 +617,8 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         || IsNicoLiveSource(source)
         || IsYouTubeLiveSource(source)
         || IsVideoSource(source)
-        || IsPatternSource(source);
+        || IsPatternSource(source)
+        || IsChannelSource(source);
 
     /// <summary>
     /// Sources the launcher hook plays: the typed ids, plus (from /screen only)
@@ -644,16 +719,46 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     }
 
     /// <summary>
-    /// The source a screen page should publish, given the route the hook sent the client to,
-    /// the movie id (room TVs only), the map the hook read from the client and, for a room TV,
-    /// the channel that tells its room instance apart from another one on the same map. Null
-    /// means the page shows its diagnostics. A typed movie id only reaches this for the typed
-    /// ids (<see cref="IsTypedSource"/>), the title card, the test page and the calibration
-    /// grid: anything else typed (the c: rectangles included) falls back to the map's
-    /// assignment. An unassigned room TV stays blank; an unassigned town screen shows the title
-    /// card.
+    /// Follows a channel:&lt;n&gt; or channel:auto main token to whatever /channel currently has
+    /// that channel assigned, keeping the reference's own extras (a room TV's channel button, or
+    /// /screen channel:&lt;n&gt; box:... key main:...) rather than the channel's, since a channel
+    /// is purely a source map: different screens frame the same channel differently, so framing
+    /// belongs on the reference, not stored on the channel (see
+    /// <see cref="IsValidChannelContentSource"/>). channel:auto uses the requesting screen's own
+    /// tvid= instead of a fixed number (a town map's screen may report a channel of its own, the
+    /// original game's apparent design), or the title card without one. An explicit channel:&lt;n&gt;
+    /// that is unassigned also resolves to the title card, same as an unassigned room TV's
+    /// channel button. Anything that is not a channel: word passes through untouched.
     /// </summary>
-    public string? Resolve(string route, string? movieId, uint? mapId, int channel = 0)
+    private string ResolveChannelIndirection(string source, uint? requestTvId)
+    {
+        var words = Normalize(source).Split(' ');
+        if (!IsChannelSource(words[0]))
+            return source;
+        var n = IsAutoChannelWord(words[0]) ? requestTvId : ChannelNumberOf(words[0]);
+        var content = n is { } number ? MainOf(GetChannelSource(number) ?? TitleCard) : TitleCard;
+        return string.Join(' ', new[] { content }.Concat(words.Skip(1)));
+    }
+
+    /// <summary>
+    /// The source a screen page should publish, given the route the hook sent the client to,
+    /// the movie id (room TVs only), the map the hook read from the client, for a room TV the
+    /// channel that tells its room instance apart from another one on the same map, and the
+    /// requesting screen's own tvid= (used only for channel:auto, see
+    /// <see cref="ResolveChannelIndirection"/>). Null means the page shows its diagnostics. A
+    /// typed movie id only reaches this for the typed ids (<see cref="IsTypedSource"/>), the
+    /// title card, the test page and the calibration grid: anything else typed (the c: rectangles
+    /// included) falls back to the map's assignment. An unassigned room TV stays blank; an
+    /// unassigned town screen defaults to channel:auto (the title card, absent a channel of its
+    /// own), same as an explicit /screen channel:auto would.
+    /// </summary>
+    public string? Resolve(
+        string route,
+        string? movieId,
+        uint? mapId,
+        int channel = 0,
+        uint? requestTvId = null
+    )
     {
         if (route == "room-tv" && movieId is not null)
         {
@@ -674,14 +779,16 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
                 return ToHookSource(typed) + " " + TimelineWords(timeline);
             }
             if (IsTypedSource(typed))
-                return ToHookSource(typed);
+                return ToHookSource(ResolveChannelIndirection(typed, requestTvId));
         }
         var entry = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
         if (entry is null)
-            return route == "room-tv" ? Blank : TitleCard;
+            return route == "room-tv"
+                ? Blank
+                : ToHookSource(ResolveChannelIndirection("channel:auto", requestTvId));
         if (string.Equals(entry.Source, TestScreen, StringComparison.OrdinalIgnoreCase))
             return null;
-        var assigned = entry.Source;
+        var assigned = ResolveChannelIndirection(entry.Source, requestTvId);
         // Town screens attenuate with distance by default; an explicit rolloff word wins, filled
         // out to the hook's seven-number form; rolloff:flat drops it.
         var words = ToHookSource(assigned).Split(' ').ToList();

--- a/aisp.Common/Game/SystemNotice.cs
+++ b/aisp.Common/Game/SystemNotice.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using aisp.Network;
 using aisp.Network.Packets.Msg;
 
@@ -8,14 +9,101 @@ public static class SystemNotice
     // DistID -5 is the client "System" / Notice chat filter (see sub_428B10 / sub_428BB0).
     public const uint DistId = unchecked((uint)-5);
 
-    public static Task SendAsync(
+    /// <summary>
+    /// The client's recv_talk_forward reads the message into a char[0x181]: it scans the first
+    /// 385 bytes for a NUL and treats a longer string as a malformed RPC, which drops the
+    /// session. The same cap applies to the client's own send_talk_post. Messages therefore
+    /// carry at most this many bytes of text before the CRLF and NUL, split into several
+    /// notifies when longer.
+    /// </summary>
+    public const int MaxLineBytes = 360;
+
+    public static async Task SendAsync(
         IPlayerSession session,
         string text,
         CancellationToken ct = default
-    ) =>
-        session.SendAsync(
-            PacketType.TalkForwardNotify,
-            new TalkForwardNotify(0, DistId, $"{text}\r\n", 0).ToBytes(),
-            ct
-        );
+    )
+    {
+        foreach (var message in Messages(text))
+            await session.SendAsync(
+                PacketType.TalkForwardNotify,
+                new TalkForwardNotify(0, DistId, $"{message}\r\n", 0).ToBytes(),
+                ct
+            );
+    }
+
+    /// <summary>
+    /// Splits a notice into messages of at most <see cref="MaxLineBytes"/> UTF-8 bytes. Lines
+    /// stay together while they fit; an over-long line wraps on spaces, or inside a word only
+    /// when the word itself is too long.
+    /// </summary>
+    public static IEnumerable<string> Messages(string text, int maxBytes = MaxLineBytes)
+    {
+        var message = new StringBuilder();
+        foreach (var (line, newParagraph) in Wrap(text, maxBytes))
+        {
+            var candidate =
+                message.Length == 0 ? line : message + (newParagraph ? "\n" : " ") + line;
+            if (message.Length > 0 && Encoding.UTF8.GetByteCount(candidate) > maxBytes)
+            {
+                yield return message.ToString();
+                message.Clear().Append(line);
+            }
+            else
+            {
+                message.Clear().Append(candidate);
+            }
+        }
+        if (message.Length > 0)
+            yield return message.ToString();
+    }
+
+    private static IEnumerable<(string Line, bool NewParagraph)> Wrap(string text, int maxBytes)
+    {
+        foreach (var paragraph in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            var line = new StringBuilder();
+            var first = true;
+            foreach (var word in paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                foreach (var piece in Pieces(word, maxBytes))
+                {
+                    var candidate = line.Length == 0 ? piece : line + " " + piece;
+                    if (line.Length > 0 && Encoding.UTF8.GetByteCount(candidate) > maxBytes)
+                    {
+                        yield return (line.ToString(), first);
+                        first = false;
+                        line.Clear().Append(piece);
+                    }
+                    else
+                    {
+                        line.Clear().Append(candidate);
+                    }
+                }
+            }
+            if (line.Length > 0)
+                yield return (line.ToString(), first);
+        }
+    }
+
+    private static IEnumerable<string> Pieces(string word, int maxBytes)
+    {
+        if (Encoding.UTF8.GetByteCount(word) <= maxBytes)
+        {
+            yield return word;
+            yield break;
+        }
+        var piece = new StringBuilder();
+        foreach (var rune in word.EnumerateRunes())
+        {
+            if (piece.Length > 0 && Encoding.UTF8.GetByteCount(piece + rune.ToString()) > maxBytes)
+            {
+                yield return piece.ToString();
+                piece.Clear();
+            }
+            piece.Append(rune.ToString());
+        }
+        if (piece.Length > 0)
+            yield return piece.ToString();
+    }
 }

--- a/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
@@ -76,7 +76,10 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
                 session,
                 session.MyRoomId,
                 PacketType.NotifyNicotvSetMovie,
-                new NotifyNicotvSetMovie(nicotvId, nicotv.MovieId).ToBytes(),
+                new NotifyNicotvSetMovie(
+                    nicotvId,
+                    NicotvMapper.WithNicotvId(nicotv.MovieId, nicotvId)
+                ).ToBytes(),
                 includeSource: false,
                 ct
             );

--- a/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
@@ -38,7 +38,6 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
         );
         var previousPlayback = existing?.PlaybackState;
         var previousMovieId = existing?.MovieId;
-        var previousCommentVisibility = existing?.CommentVisibility;
 
         var nicotv = await nicotvRepository.UpdateForFurnitureAsync(
             roomId,
@@ -51,8 +50,12 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
 
         var nicotvId = checked((uint)nicotv.Id);
 
-        // Client has no dedicated send for comment-visible; open carries the full NicotvData
-        // snapshot, so broadcast peer notifies for fields that changed.
+        // Open carries the client's NicotvData snapshot, so peers get notifies for the fields that
+        // changed. Not comment visibility: the TV panel builds this snapshot from constants
+        // (playing, comments visible) whatever the TV shows, and the client has no request for
+        // that field at all (its panel button is an empty case in the binary). The stored value
+        // is the server's own default, which reaches the page in its title and is never read
+        // back from here; only NotifyNicotvSetCommentVisible can change it on a running client.
         if (previousPlayback is null || previousPlayback != nicotv.PlaybackState)
         {
             await MyRoomFurnitureNotification.BroadcastToRoomAsync(
@@ -81,35 +84,6 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
                     NicotvMapper.WithNicotvId(nicotv.MovieId, nicotvId)
                 ).ToBytes(),
                 includeSource: false,
-                ct
-            );
-        }
-
-        if (
-            previousCommentVisibility is null
-            || previousCommentVisibility != nicotv.CommentVisibility
-        )
-        {
-            await session.SendAsync(
-                PacketType.NicotvSetCommentVisibleResponse,
-                new NicotvSetCommentVisibleResponse(0, nicotvId).ToBytes(),
-                ct
-            );
-            // Comment visibility has no dedicated set request of its own (confirmed: the client
-            // binary has no send for it): the toggle button re-sends open-by-furniture with the
-            // new snapshot, diffed above. recv_nicotv_set_comment_visible_r (just sent) does not
-            // call the JS setter either, only recv_notify_nicotv_set_comment_visible does, so the
-            // clicker needs this notify too, same as set-movie's own _r-is-a-no-op case.
-            await MyRoomFurnitureNotification.BroadcastToRoomAsync(
-                state,
-                session,
-                session.MyRoomId,
-                PacketType.NotifyNicotvSetCommentVisible,
-                new NotifyNicotvSetCommentVisible(
-                    nicotvId,
-                    (uint)nicotv.CommentVisibility
-                ).ToBytes(),
-                includeSource: true,
                 ct
             );
         }

--- a/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvOpenByFurnitureHandler.cs
@@ -92,6 +92,11 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
                 new NicotvSetCommentVisibleResponse(0, nicotvId).ToBytes(),
                 ct
             );
+            // Comment visibility has no dedicated set request of its own (confirmed: the client
+            // binary has no send for it): the toggle button re-sends open-by-furniture with the
+            // new snapshot, diffed above. recv_nicotv_set_comment_visible_r (just sent) does not
+            // call the JS setter either, only recv_notify_nicotv_set_comment_visible does, so the
+            // clicker needs this notify too, same as set-movie's own _r-is-a-no-op case.
             await MyRoomFurnitureNotification.BroadcastToRoomAsync(
                 state,
                 session,
@@ -101,7 +106,7 @@ public sealed class AreaNicotvOpenByFurnitureHandler(
                     nicotvId,
                     (uint)nicotv.CommentVisibility
                 ).ToBytes(),
-                includeSource: false,
+                includeSource: true,
                 ct
             );
         }

--- a/aisp.Common/Handlers/Area/AreaNicotvPlayHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvPlayHandler.cs
@@ -37,13 +37,17 @@ public sealed class AreaNicotvPlayHandler(INicotvRepository nicotvRepository, Sh
         if (nicotv is null)
             return new NicotvPlayResponse(1, request.NicotvId);
 
+        // The client calls ext_play on its own screen browser for this notify regardless of
+        // Status (confirmed by testing both values), so Status goes out as-is rather than as a
+        // play/pause toggle. includeSource lets the sender see its own copy too, same as
+        // AreaNicotvSetMovieHandler.
         await MyRoomFurnitureNotification.BroadcastToRoomAsync(
             state,
             session,
             session.MyRoomId,
             PacketType.NotifyNicotvPlay,
             new NotifyNicotvPlay(request.NicotvId, request.Status).ToBytes(),
-            includeSource: false,
+            includeSource: true,
             ct
         );
         return new NicotvPlayResponse(0, request.NicotvId);

--- a/aisp.Common/Handlers/Area/AreaNicotvPlayHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvPlayHandler.cs
@@ -6,9 +6,11 @@ using aisp.Network.Packets.Area;
 
 namespace aisp.Common.Handlers.Area;
 
-public sealed class AreaNicotvPlayHandler(INicotvRepository nicotvRepository, SharedState state)
-    : PacketHandlerBase<NicotvPlayRequest, NicotvPlayResponse>,
-        IRequiresAuthenticatedSession
+public sealed class AreaNicotvPlayHandler(
+    INicotvRepository nicotvRepository,
+    SharedState state,
+    ScreenAssignments screenAssignments
+) : PacketHandlerBase<NicotvPlayRequest, NicotvPlayResponse>, IRequiresAuthenticatedSession
 {
     public override PacketType RequestType => PacketType.NicotvPlayRequest;
     public override PacketType ResponseType => PacketType.NicotvPlayResponse;
@@ -37,10 +39,22 @@ public sealed class AreaNicotvPlayHandler(INicotvRepository nicotvRepository, Sh
         if (nicotv is null)
             return new NicotvPlayResponse(1, request.NicotvId);
 
+        // The pause button: moves that TV's shared timeline for everyone in the room with it.
+        // n: keys the timeline by this specific TV, same as AreaNicotvSetMovieHandler.
+        var status = (NicotvPlaybackState)request.Status;
+        if (status is NicotvPlaybackState.Paused or NicotvPlaybackState.Playing)
+            screenAssignments.ControlMovie(
+                session.MapId,
+                session.ChannelId,
+                NicotvMapper.WithNicotvId(nicotv.MovieId, request.NicotvId),
+                status == NicotvPlaybackState.Paused ? "pause" : "resume"
+            );
+
         // The client calls ext_play on its own screen browser for this notify regardless of
         // Status (confirmed by testing both values), so Status goes out as-is rather than as a
-        // play/pause toggle. includeSource lets the sender see its own copy too, same as
-        // AreaNicotvSetMovieHandler.
+        // play/pause toggle; the shared timeline (moved above) and the page's poll of it are
+        // what pause and resume actually run on. includeSource lets the sender see its own copy
+        // too, same as AreaNicotvSetMovieHandler.
         await MyRoomFurnitureNotification.BroadcastToRoomAsync(
             state,
             session,

--- a/aisp.Common/Handlers/Area/AreaNicotvSetChannelHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvSetChannelHandler.cs
@@ -38,13 +38,15 @@ public sealed class AreaNicotvSetChannelHandler(
         if (nicotv is null)
             return new NicotvSetChannelResponse(0, 0);
 
+        // The client's set_channel_r handler is a no-op, same as set_movie_r, so the sender needs
+        // the notify as well to load the channel on its own TV.
         await MyRoomFurnitureNotification.BroadcastToRoomAsync(
             state,
             session,
             session.MyRoomId,
             PacketType.NotifyNicotvSetChannel,
             new NotifyNicotvSetChannel(request.NicotvId, request.ChannelId).ToBytes(),
-            includeSource: false,
+            includeSource: true,
             ct
         );
         return new NicotvSetChannelResponse(request.NicotvId, request.ChannelId);

--- a/aisp.Common/Handlers/Area/AreaNicotvSetMovieHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvSetMovieHandler.cs
@@ -41,7 +41,9 @@ public sealed class AreaNicotvSetMovieHandler(INicotvRepository nicotvRepository
             session.MyRoomId,
             PacketType.NotifyNicotvSetMovie,
             new NotifyNicotvSetMovie(request.NicotvId, request.MovieId).ToBytes(),
-            includeSource: false,
+            // The client ignores set_movie_r (an 8-byte no-op, verified); only the notify makes
+            // the sender's own TV load the movie, so it must get it too.
+            includeSource: true,
             ct
         );
         return new NicotvSetMovieResponse(0, request.NicotvId);

--- a/aisp.Common/Handlers/Area/AreaNicotvSetMovieHandler.cs
+++ b/aisp.Common/Handlers/Area/AreaNicotvSetMovieHandler.cs
@@ -5,9 +5,11 @@ using aisp.Network.Packets.Area;
 
 namespace aisp.Common.Handlers.Area;
 
-public sealed class AreaNicotvSetMovieHandler(INicotvRepository nicotvRepository, SharedState state)
-    : PacketHandlerBase<NicotvSetMovieRequest, NicotvSetMovieResponse>,
-        IRequiresAuthenticatedSession
+public sealed class AreaNicotvSetMovieHandler(
+    INicotvRepository nicotvRepository,
+    SharedState state,
+    ScreenAssignments screenAssignments
+) : PacketHandlerBase<NicotvSetMovieRequest, NicotvSetMovieResponse>, IRequiresAuthenticatedSession
 {
     public override PacketType RequestType => PacketType.NicotvSetMovieRequest;
     public override PacketType ResponseType => PacketType.NicotvSetMovieResponse;
@@ -35,12 +37,22 @@ public sealed class AreaNicotvSetMovieHandler(INicotvRepository nicotvRepository
         if (nicotv is null)
             return new NicotvSetMovieResponse(1, request.NicotvId);
 
+        // The n: tag rides along on the room TV's own movie id: the screen page
+        // round-trips it into its movieid= URL, letting the server key the shared timeline (and,
+        // on the next poll, resolve content) by this specific TV rather than by map and channel,
+        // which do not reliably tell one player's room from another's.
+        var taggedMovieId = NicotvMapper.WithNicotvId(request.MovieId, request.NicotvId);
+
+        // A movie picked on the TV plays from the start for the room, even if that same id is
+        // already mid-playback somewhere else.
+        screenAssignments.SetMovie(session.MapId, session.ChannelId, taggedMovieId);
+
         await MyRoomFurnitureNotification.BroadcastToRoomAsync(
             state,
             session,
             session.MyRoomId,
             PacketType.NotifyNicotvSetMovie,
-            new NotifyNicotvSetMovie(request.NicotvId, request.MovieId).ToBytes(),
+            new NotifyNicotvSetMovie(request.NicotvId, taggedMovieId).ToBytes(),
             // The client ignores set_movie_r (an 8-byte no-op, verified); only the notify makes
             // the sender's own TV load the movie, so it must get it too.
             includeSource: true,

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -31,6 +31,7 @@ public class CmdExecHandler(
     IAdventureWorkRepository adventureWorks,
     IWordFilter wordFilter,
     ScreenAssignments screenAssignments,
+    INicotvRepository nicotvRepository,
     IOptions<ServerOptions> serverOptions,
     ILogger<CmdExecHandler> logger
 ) : IPacketHandler, IRequiresAuthenticatedSession
@@ -82,6 +83,12 @@ public class CmdExecHandler(
         if (cmd is "screen" or "display")
         {
             await HandleScreenCommandAsync(session, request.Arguments, ct);
+            return;
+        }
+
+        if (cmd is "channel")
+        {
+            await HandleChannelCommandAsync(session, request.Arguments, ct);
             return;
         }
 
@@ -925,15 +932,16 @@ public class CmdExecHandler(
 
     /// <summary>
     /// /screen &lt;source&gt; plays a source on every in-game screen of the map the player is on
-    /// (the Akihabara display, the Stage billboard): the ids anyone may type into a room TV
-    /// (tw:, twe:, yt:, ytl:, lv…, lv…:vod, sm…, pattern:live, pattern:vod, title), plus
-    /// streamlink:&lt;url&gt; or
-    /// stream:&lt;url&gt; for the launcher hook to decode, electron:&lt;http(s) url&gt; for an
-    /// off-screen browser overlay, or an http(s) URL of a web page to show in IE. /screen off
-    /// clears it; /screen alone shows it.
+    /// (the Akihabara display, the Stage billboard, TVs on a channel): the ids anyone may type
+    /// into a room TV (tw:, twe:, yt:, ytl:, lv…, lv…:vod, sm…, pattern:live, pattern:vod,
+    /// title), plus streamlink:&lt;url&gt; or stream:&lt;url&gt; for the launcher hook to decode,
+    /// electron:&lt;http(s) url&gt; for an off-screen browser overlay, or an http(s) URL of a
+    /// web page to show in IE. /screen off clears it; /screen alone shows it.
     /// The Stage billboard (see ScreenAssignments.StageMapId) reloads at once through
-    /// notify_nicolive_reload; any other screen (a town map's own, Akihabara confirmed) has no
-    /// such thing and only picks up a change on its next poll, a few seconds later.
+    /// notify_nicolive_reload, same as /channel does when it changes a channel the Stage is
+    /// bound to (see HandleChannelCommandAsync); any other screen (a town map's own, Akihabara
+    /// confirmed, or another map bound to a channel) has no such thing and only picks up a
+    /// change on its next poll.
     /// </summary>
     private async Task HandleScreenCommandAsync(
         IPlayerSession session,
@@ -997,6 +1005,7 @@ public class CmdExecHandler(
                 "/screen <source> [extras]. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
                     + "yt:<id> (YouTube), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
+                    + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
                     + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy,\n"
@@ -1033,6 +1042,111 @@ public class CmdExecHandler(
             clearing
                 ? $"Map {mapId}: screens back to the default page ({reloaded} client(s) told); open screens follow within a few seconds."
                 : $"Map {mapId}: screens set to {source} ({reloaded} client(s) told); open screens follow within a few seconds.",
+            ct
+        );
+    }
+
+    /// <summary>
+    /// /channel &lt;n&gt; &lt;source&gt; assigns channel n's content (livestream only, since a
+    /// channel has no per-viewer pause/resume/seek) and pushes every room TV already tuned to it
+    /// a fresh set-channel notify so it reloads at once, the way /screen reloads the live
+    /// billboard. /channel &lt;n&gt; off clears it. Binding a map's own screens to a channel
+    /// needs no separate command: /screen channel:n does it, channel:n being an ordinary source
+    /// like tw: or yt:. Bound map screens other than the Stage have no reload packet of their own
+    /// (nothing else in the protocol does this) and only pick a content change up on their next
+    /// poll, same as any other /screen change.
+    /// </summary>
+    private async Task HandleChannelCommandAsync(
+        IPlayerSession session,
+        IReadOnlyList<string> args,
+        CancellationToken ct
+    )
+    {
+        if (session.User is not { } actor || !actor.Role.CanKickOrBan())
+        {
+            await SendSystemNoticeAsync(session, "/channel is for moderators.", ct);
+            return;
+        }
+        if (args.Count < 2 || !uint.TryParse(args[0], out var channelNumber))
+        {
+            await SendSystemNoticeAsync(
+                session,
+                "/channel <n> <source> sets what channel n shows (livestream only: tw:, twe:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL)"
+                    + " or off to clear it. To have a map's own screens follow a channel instead, use /screen channel:<n>.",
+                ct
+            );
+            return;
+        }
+
+        var source = string.Join(" ", args.Skip(1)).Trim();
+        var clearing = source is "off" or "clear" or "none";
+        if (clearing)
+            screenAssignments.ClearChannelSource(channelNumber);
+        else if (ScreenAssignments.IsValidChannelContentSource(source))
+            screenAssignments.SetChannelSource(channelNumber, source);
+        else
+        {
+            await SendSystemNoticeAsync(
+                session,
+                "/channel <n> <source>: a livestream only (tw:, twe:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL), or off to clear.",
+                ct
+            );
+            return;
+        }
+        logger.LogInformation(
+            "CmdExecHandler: user {UserId} set channel {Channel} to {Source}",
+            actor.Id,
+            channelNumber,
+            clearing ? "(default)" : source
+        );
+
+        // Every room TV already tuned to this channel reloads at once: its own Nicotv id and
+        // channel number are unchanged, so this is exactly the notify AreaNicotvSetChannelHandler
+        // sends for a player's own "ai ch" press, and the resolve-time database lookup it
+        // triggers picks up the content just assigned above.
+        var tuned = await nicotvRepository.GetByChannelAsync(channelNumber, ct);
+        var roomsNotified = 0;
+        foreach (var nicotv in tuned)
+        {
+            var recipients = state
+                .AreaClients.Where(c => c.MyRoomId == (uint)nicotv.RoomId)
+                .ToList();
+            if (recipients.Count == 0)
+                continue;
+            var notify = new NotifyNicotvSetChannel(
+                checked((uint)nicotv.Id),
+                channelNumber
+            ).ToBytes();
+            foreach (var client in recipients)
+                await client.SendAsync(PacketType.NotifyNicotvSetChannel, notify, ct);
+            roomsNotified++;
+        }
+
+        // A map bound to this channel via /screen channel:<n> gets the same reload /screen itself
+        // sends, and just as scoped: only the Stage's own screen reacts to this notify (see
+        // ScreenAssignments.StageMapId), so a bound town screen only picks this up on its next
+        // poll.
+        var liveId = serverOptions.Value.NicoLive.LiveId?.Trim() ?? "";
+        var boundMaps = screenAssignments.GetMapsBoundToChannel(channelNumber);
+        var mapsNotified = 0;
+        if (!string.IsNullOrEmpty(liveId) && boundMaps.Contains(ScreenAssignments.StageMapId))
+        {
+            var recipients = state
+                .AreaClients.Where(c => c.MapId == ScreenAssignments.StageMapId)
+                .ToList();
+            if (recipients.Count > 0)
+            {
+                var reload = new NotifyNicoliveReload(liveId).ToBytes();
+                foreach (var client in recipients)
+                    await client.SendAsync(PacketType.NotifyNicoliveReload, reload, ct);
+                mapsNotified = 1;
+            }
+        }
+        await SendSystemNoticeAsync(
+            session,
+            clearing
+                ? $"Channel {channelNumber}: cleared ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {mapsNotified} of {boundMaps.Count} map screen(s) told, the rest follow within a few seconds)."
+                : $"Channel {channelNumber}: set to {source} ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {mapsNotified} of {boundMaps.Count} map screen(s) told, the rest follow within a few seconds).",
             ct
         );
     }

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1,3 +1,4 @@
+using aisp.Common.Config;
 using aisp.Common.DAL.Repositories;
 using aisp.Common.Game;
 using aisp.Common.Handlers.Area;
@@ -9,6 +10,7 @@ using aisp.Network.Packets.Area;
 using aisp.Network.Packets.Msg;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Character = aisp.Common.DAL.Entities.Character;
 
 namespace aisp.Common.Handlers.Msg;
@@ -28,6 +30,8 @@ public class CmdExecHandler(
     ITextLocaliser localiser,
     IAdventureWorkRepository adventureWorks,
     IWordFilter wordFilter,
+    ScreenAssignments screenAssignments,
+    IOptions<ServerOptions> serverOptions,
     ILogger<CmdExecHandler> logger
 ) : IPacketHandler, IRequiresAuthenticatedSession
 {
@@ -72,6 +76,12 @@ public class CmdExecHandler(
                     session.User?.Id ?? session.UserId
                 );
             }
+            return;
+        }
+
+        if (cmd is "screen" or "display")
+        {
+            await HandleScreenCommandAsync(session, request.Arguments, ct);
             return;
         }
 
@@ -911,6 +921,97 @@ public class CmdExecHandler(
             return state.GetAreaSessionByCharacterId(msgSession.CharacterId);
 
         return null;
+    }
+
+    /// <summary>
+    /// /screen &lt;source&gt; plays a source on every in-game screen of the map the player is on
+    /// (the Akihabara display, the Stage billboard): the ids anyone may type into a room TV
+    /// (tw:, twe:, ytl:, lv…, pattern:live, title), plus streamlink:&lt;url&gt; or
+    /// stream:&lt;url&gt; for the launcher hook to decode, electron:&lt;http(s) url&gt; for an
+    /// off-screen browser overlay, or an http(s) URL of a web page to show in IE. /screen off
+    /// clears it; /screen alone shows it.
+    /// The Stage billboard (see ScreenAssignments.StageMapId) reloads at once through
+    /// notify_nicolive_reload; any other screen (a town map's own, Akihabara confirmed) has no
+    /// such thing and only picks up a change on its next poll, a few seconds later.
+    /// </summary>
+    private async Task HandleScreenCommandAsync(
+        IPlayerSession session,
+        IReadOnlyList<string> args,
+        CancellationToken ct
+    )
+    {
+        if (session.User is not { } actor || !actor.Role.CanKickOrBan())
+        {
+            await SendSystemNoticeAsync(session, "/screen is for moderators.", ct);
+            return;
+        }
+        var areaClient = ResolveAreaClient(session);
+        if (areaClient is null)
+        {
+            await SendSystemNoticeAsync(session, "/screen needs you to be on a map.", ct);
+            return;
+        }
+        var mapId = areaClient.MapId;
+        if (args.Count == 0)
+        {
+            var current = screenAssignments.Get(mapId);
+            await SendSystemNoticeAsync(
+                session,
+                current is null
+                    ? $"Map {mapId}: screens show the default page. /screen tw:<channel> | stream:<url> | <page url> | title | off"
+                    : $"Map {mapId}: screens play {current}. /screen off to clear.",
+                ct
+            );
+            return;
+        }
+
+        // The client splits command arguments on commas and spaces; the source syntax uses
+        // neither inside a word (coordinates are slash-separated).
+        var source = string.Join(" ", args).Trim();
+        var clearing = source is "off" or "clear" or "none";
+        if (clearing)
+            screenAssignments.Clear(mapId);
+        else if (ScreenAssignments.IsValidSource(source))
+            screenAssignments.Set(mapId, source);
+        else
+        {
+            await SendSystemNoticeAsync(
+                session,
+                "/screen <source>. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
+                    + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
+                    + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.",
+                ct
+            );
+            return;
+        }
+        logger.LogInformation(
+            "CmdExecHandler: user {UserId} set the screens of map {MapId} to {Source}",
+            actor.Id,
+            mapId,
+            clearing ? "(default)" : source
+        );
+
+        // The Nico Live billboard re-navigates on this notify; the page it fetches carries the
+        // new source. Confirmed by testing to do nothing on a map without one (the shopping
+        // mall), so only bother sending it on the one map that has it.
+        var liveId = serverOptions.Value.NicoLive.LiveId?.Trim() ?? "";
+        var reloaded = 0;
+        if (!string.IsNullOrEmpty(liveId) && mapId == ScreenAssignments.StageMapId)
+        {
+            var reload = new NotifyNicoliveReload(liveId).ToBytes();
+            foreach (var client in state.AreaClients.Where(c => c.MapId == mapId))
+            {
+                await client.SendAsync(PacketType.NotifyNicoliveReload, reload, ct);
+                reloaded++;
+            }
+        }
+        await SendSystemNoticeAsync(
+            session,
+            clearing
+                ? $"Map {mapId}: screens back to the default page ({reloaded} client(s) told); open screens follow within a few seconds."
+                : $"Map {mapId}: screens set to {source} ({reloaded} client(s) told); open screens follow within a few seconds.",
+            ct
+        );
     }
 
     private async Task HandleKickCommandAsync(

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -983,7 +983,8 @@ public class CmdExecHandler(
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
                     + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy,\n"
                     + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
-                    + "key[:RRGGBB] to colour-key it.",
+                    + "key[:RRGGBB] to colour-key it,\n"
+                    + "fps:N (15/20/25/30/50/60), rolloff:near/far, rolloff:near/far/max/min (gains to fade between, default 1/0), rolloff:x/y/z/near/far, rolloff:x/y/z/near/far/max/min or rolloff:flat, pan to also stereo-pan by bearing.",
                 ct
             );
             return;

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1279,7 +1279,11 @@ public class CmdExecHandler(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "CmdExecHandler: failed to create report ticket for user {UserId}", user.Id);
+            logger.LogError(
+                ex,
+                "CmdExecHandler: failed to create report ticket for user {UserId}",
+                user.Id
+            );
             await SendModerationNoticeAsync(session, L.Cmd.ReportFailed, ct);
         }
     }
@@ -1409,16 +1413,7 @@ public class CmdExecHandler(
         IPlayerSession session,
         string text,
         CancellationToken ct
-    )
-    {
-        // DistID -5 is the client "System" / Notice chat filter (see sub_428B10 / sub_428BB0).
-        const uint systemDistId = unchecked((uint)-5);
-        return session.SendAsync(
-            PacketType.TalkForwardNotify,
-            new TalkForwardNotify(0, systemDistId, $"{text}\r\n", 0).ToBytes(),
-            ct
-        );
-    }
+    ) => SystemNotice.SendAsync(session, text, ct);
 
     private static byte[] CreateTeleportNotify(Character cha, uint objId, MovementData pos)
     {

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1103,11 +1103,15 @@ public class CmdExecHandler(
         // Every room TV already tuned to this channel reloads at once: its own Nicotv id and
         // channel number are unchanged, so this is exactly the notify AreaNicotvSetChannelHandler
         // sends for a player's own "ai ch" press, and the resolve-time database lookup it
-        // triggers picks up the content just assigned above.
+        // triggers picks up the content just assigned above. Not a TV that is switched off: the
+        // client takes the notify as the TV showing its channel and turns it on, which only its
+        // owner's power button should do; it reads the channel's new content when opened.
         var tuned = await nicotvRepository.GetByChannelAsync(channelNumber, ct);
         var roomsNotified = 0;
         foreach (var nicotv in tuned)
         {
+            if (nicotv.PlaybackState == NicotvPlaybackState.Closed)
+                continue;
             var recipients = state
                 .AreaClients.Where(c => c.MyRoomId == (uint)nicotv.RoomId)
                 .ToList();

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -926,7 +926,8 @@ public class CmdExecHandler(
     /// <summary>
     /// /screen &lt;source&gt; plays a source on every in-game screen of the map the player is on
     /// (the Akihabara display, the Stage billboard): the ids anyone may type into a room TV
-    /// (tw:, twe:, ytl:, lv…, pattern:live, title), plus streamlink:&lt;url&gt; or
+    /// (tw:, twe:, yt:, ytl:, lv…, lv…:vod, sm…, pattern:live, pattern:vod, title), plus
+    /// streamlink:&lt;url&gt; or
     /// stream:&lt;url&gt; for the launcher hook to decode, electron:&lt;http(s) url&gt; for an
     /// off-screen browser overlay, or an http(s) URL of a web page to show in IE. /screen off
     /// clears it; /screen alone shows it.
@@ -958,8 +959,24 @@ public class CmdExecHandler(
             await SendSystemNoticeAsync(
                 session,
                 current is null
-                    ? $"Map {mapId}: screens show the default page. /screen tw:<channel> | stream:<url> | <page url> | title | off"
+                    ? $"Map {mapId}: screens show the default page. /screen tw:<channel> | yt:<id> | stream:<url> | <page url> | title | off"
                     : $"Map {mapId}: screens play {current}. /screen off to clear.",
+                ct
+            );
+            return;
+        }
+
+        // pause / resume / seek <seconds> steer the map's video without changing the source.
+        var verb = args[0].ToLowerInvariant();
+        if (verb is "pause" or "resume" or "seek")
+        {
+            var action = verb == "seek" ? "seek:" + (args.Count > 1 ? args[1] : "") : verb;
+            var applied = screenAssignments.Control(mapId, action);
+            await SendSystemNoticeAsync(
+                session,
+                applied
+                    ? $"Map {mapId}: video {verb}{(verb == "seek" ? " " + args[1] : "")}."
+                    : $"Map {mapId}: no video to {verb} (set one with /screen yt:<id>, sm<id> or pattern:vod).",
                 ct
             );
             return;
@@ -978,6 +995,7 @@ public class CmdExecHandler(
             await SendSystemNoticeAsync(
                 session,
                 "/screen <source> [extras]. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
+                    + "yt:<id> (YouTube), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -977,9 +977,13 @@ public class CmdExecHandler(
         {
             await SendSystemNoticeAsync(
                 session,
-                "/screen <source>. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
+                "/screen <source> [extras]. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
-                    + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.",
+                    + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"
+                    + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
+                    + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy,\n"
+                    + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
+                    + "key[:RRGGBB] to colour-key it.",
                 ct
             );
             return;

--- a/aisp.Server/Program.cs
+++ b/aisp.Server/Program.cs
@@ -325,6 +325,7 @@ internal class Program
         app.MapAispEmuHttpEndpoints();
         app.MapAdventureHttpEndpoints();
         app.MapAdventureAdminEndpoints();
+        app.MapScreenEndpoints();
         if (portalEnabled)
         {
             app.UseStaticFiles();

--- a/aisp.Server/Program.cs
+++ b/aisp.Server/Program.cs
@@ -145,6 +145,7 @@ internal class Program
         builder
             .Services.AddOptions<ApiSettings>()
             .Bind(builder.Configuration.GetSection("ApiSettings"));
+        builder.Services.AddSingleton<ScreenAssignments>();
         builder.Services.AddSingleton<BroadcastService>();
         builder.Services.AddScoped<ModerationService>();
         builder.Services.AddScoped<UserAdminService>();

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using aisp.Common.Game;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -13,35 +15,73 @@ namespace aisp.Server;
 ///   /ai-sp/channel-screen?tvid=..&chid=.. a TV or town screen on a channel
 ///   /ai-sp/live-watch?liveid=...          the Nico Live billboard
 ///   /ai-sp/screen?url=...                 anything else the client asked aisp.jp for
+///   /ai-sp/screen-source?route=..&map=..  JSON {src} the page polls for changes
 /// All of them serve the same page: it shows which route and parameters it got, implements the
-/// script contract the client drives (external_nico_0.ext_*), and publishes volume and mute in
-/// its title for the hook.
+/// script contract the client drives (external_nico_0.ext_*), and publishes volume, mute and the
+/// source to play in its title for the hook. The source is decided here from ScreenAssignments.
 /// </summary>
 internal static class ScreenEndpointsExtensions
 {
     private static readonly string[] Routes = ["room-tv", "channel-screen", "live-watch", "screen"];
+    private const string TitleMarker = "<title>aisp:vol=100;mute=0</title>";
 
     internal static WebApplication MapScreenEndpoints(this WebApplication app)
     {
         foreach (var route in Routes)
             app.MapGet(
                 "/ai-sp/" + route,
-                (HttpContext context, IWebHostEnvironment environment) =>
-                    ServePage(context, environment)
+                (
+                    HttpContext context,
+                    IWebHostEnvironment environment,
+                    ScreenAssignments assignments
+                ) => ServePage(route, context, environment, assignments)
             );
+        // Polled by the page so a changed assignment reaches screens that are already open.
+        app.MapGet(
+            "/ai-sp/screen-source",
+            (HttpContext context, ScreenAssignments assignments) =>
+            {
+                var query = context.Request.Query;
+                uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
+                var source = assignments.Resolve(
+                    query["route"].ToString(),
+                    query["movieid"],
+                    mapId
+                );
+                context.Response.Headers.CacheControl = "no-store";
+                return Results.Json(new { src = source ?? "" });
+            }
+        );
         return app;
     }
 
     private static async Task<IResult> ServePage(
+        string route,
         HttpContext context,
-        IWebHostEnvironment environment
+        IWebHostEnvironment environment,
+        ScreenAssignments assignments
     )
     {
         var file = environment.WebRootFileProvider.GetFileInfo("screen/screen.html");
         if (!file.Exists || file.PhysicalPath is null)
             return Results.NotFound();
 
+        var query = context.Request.Query;
+        uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
+        var source = assignments.Resolve(route, query["movieid"], mapId);
+
+        // A room TV never needs the page to poll: the client re-navigates it on every assignment
+        // change (movie set, channel switch, room re-entry). live-watch (the Stage) is pushed
+        // too: /screen sends it notify_nicolive_reload (CmdExecHandler). A /channel-screen is a
+        // town screen (confirmed on Akihabara) with neither guarantee, so it alone keeps polling.
+        var noPoll = route is "room-tv" or "live-watch";
+        var titleSuffix =
+            (noPoll ? ";nopoll=1" : "")
+            + (source is not null ? $";src={WebUtility.HtmlEncode(source)}" : "");
+
         var html = await File.ReadAllTextAsync(file.PhysicalPath, context.RequestAborted);
+        if (titleSuffix.Length > 0)
+            html = html.Replace(TitleMarker, $"<title>aisp:vol=100;mute=0{titleSuffix}</title>");
 
         // The control fetches a page once per screen and the client keeps drawing that document,
         // so nothing here should ever be cached or redirected after it loaded.

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -36,6 +36,40 @@ internal static class ScreenEndpointsExtensions
                     ScreenAssignments assignments
                 ) => ServePage(route, context, environment, assignments)
             );
+        // Moves a video's shared timeline for everyone; the reply is the new source line. The
+        // page does not use it yet: the client calls its ext_play/ext_pause around its own
+        // lifecycle (leaving a map, arriving), which would pause the video for everyone.
+        app.MapPost(
+            "/ai-sp/screen-control",
+            (HttpContext context, ScreenAssignments assignments, ILoggerFactory loggers) =>
+            {
+                var query = context.Request.Query;
+                uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
+                var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
+                var action = query["action"].ToString();
+                var route = query["route"].ToString();
+                string? movieId = query["movieid"];
+                var applied =
+                    route == "room-tv" && !string.IsNullOrEmpty(movieId)
+                        ? assignments.ControlMovie(mapId ?? 0, channel, movieId, action)
+                        : mapId is { } m && assignments.Control(m, action);
+                loggers
+                    .CreateLogger("aisp.Server.ScreenEvents")
+                    .LogInformation(
+                        "screen control {Action} on route {Route} map {Map} movie {Movie} from {Remote}: {Applied}",
+                        action,
+                        route,
+                        mapId,
+                        movieId,
+                        context.Connection.RemoteIpAddress,
+                        applied ? "applied" : "ignored"
+                    );
+                context.Response.Headers.CacheControl = "no-store";
+                return Results.Json(
+                    new { applied, src = assignments.Resolve(route, movieId, mapId, channel) ?? "" }
+                );
+            }
+        );
         // Polled by the page so a changed assignment reaches screens that are already open.
         app.MapGet(
             "/ai-sp/screen-source",
@@ -43,10 +77,12 @@ internal static class ScreenEndpointsExtensions
             {
                 var query = context.Request.Query;
                 uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
+                var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
                 var source = assignments.Resolve(
                     query["route"].ToString(),
                     query["movieid"],
-                    mapId
+                    mapId,
+                    channel
                 );
                 context.Response.Headers.CacheControl = "no-store";
                 return Results.Json(new { src = source ?? "" });
@@ -68,7 +104,8 @@ internal static class ScreenEndpointsExtensions
 
         var query = context.Request.Query;
         uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
-        var source = assignments.Resolve(route, query["movieid"], mapId);
+        var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
+        var source = assignments.Resolve(route, query["movieid"], mapId, channel);
 
         // A room TV never needs the page to poll: the client re-navigates it on every assignment
         // change (movie set, channel switch, room re-entry). live-watch (the Stage) is pushed

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using aisp.Common.DAL.Repositories;
 using aisp.Common.Game;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -33,22 +34,32 @@ internal static class ScreenEndpointsExtensions
                 (
                     HttpContext context,
                     IWebHostEnvironment environment,
-                    ScreenAssignments assignments
-                ) => ServePage(route, context, environment, assignments)
+                    ScreenAssignments assignments,
+                    INicotvRepository nicotvRepository
+                ) => ServePage(route, context, environment, assignments, nicotvRepository)
             );
         // Moves a video's shared timeline for everyone; the reply is the new source line. The
         // page does not use it yet: the client calls its ext_play/ext_pause around its own
         // lifecycle (leaving a map, arriving), which would pause the video for everyone.
         app.MapPost(
             "/ai-sp/screen-control",
-            (HttpContext context, ScreenAssignments assignments, ILoggerFactory loggers) =>
+            async (
+                HttpContext context,
+                ScreenAssignments assignments,
+                INicotvRepository nicotvRepository,
+                ILoggerFactory loggers
+            ) =>
             {
                 var query = context.Request.Query;
                 uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
                 var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
                 var action = query["action"].ToString();
-                var route = query["route"].ToString();
-                string? movieId = query["movieid"];
+                var (route, movieId) = await ResolveRoomTvAsync(
+                    query["route"].ToString(),
+                    query,
+                    nicotvRepository,
+                    context.RequestAborted
+                );
                 var applied =
                     route == "room-tv" && !string.IsNullOrEmpty(movieId)
                         ? assignments.ControlMovie(mapId ?? 0, channel, movieId, action)
@@ -73,17 +84,22 @@ internal static class ScreenEndpointsExtensions
         // Polled by the page so a changed assignment reaches screens that are already open.
         app.MapGet(
             "/ai-sp/screen-source",
-            (HttpContext context, ScreenAssignments assignments) =>
+            async (
+                HttpContext context,
+                ScreenAssignments assignments,
+                INicotvRepository nicotvRepository
+            ) =>
             {
                 var query = context.Request.Query;
                 uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
                 var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
-                var source = assignments.Resolve(
+                var (route, movieId) = await ResolveRoomTvAsync(
                     query["route"].ToString(),
-                    query["movieid"],
-                    mapId,
-                    channel
+                    query,
+                    nicotvRepository,
+                    context.RequestAborted
                 );
+                var source = assignments.Resolve(route, movieId, mapId, channel);
                 context.Response.Headers.CacheControl = "no-store";
                 return Results.Json(new { src = source ?? "" });
             }
@@ -91,11 +107,36 @@ internal static class ScreenEndpointsExtensions
         return app;
     }
 
+    /// <summary>
+    /// A room TV may identify the furniture it's for as an n: tag on movieid (the tag the server
+    /// appends to its own Notify* broadcasts and get-info/open responses): when it does,
+    /// the database's own movie state for that Nicotv is authoritative over whatever the
+    /// client's URL still says, and the route becomes room-tv so
+    /// <see cref="ScreenAssignments.Resolve"/> plays it.
+    /// </summary>
+    private static async Task<(string Route, string? MovieId)> ResolveRoomTvAsync(
+        string route,
+        IQueryCollection query,
+        INicotvRepository nicotvRepository,
+        CancellationToken ct
+    )
+    {
+        if (ScreenAssignments.TryGetNicotvId(query["movieid"], out var nicotvId))
+        {
+            var nicotv = await nicotvRepository.GetByIdAsync(nicotvId, ct);
+            var content = string.IsNullOrEmpty(nicotv?.MovieId) ? null : nicotv.MovieId;
+            return ("room-tv", content is null ? null : $"{content} n:{nicotvId}");
+        }
+
+        return (route, query["movieid"]);
+    }
+
     private static async Task<IResult> ServePage(
         string route,
         HttpContext context,
         IWebHostEnvironment environment,
-        ScreenAssignments assignments
+        ScreenAssignments assignments,
+        INicotvRepository nicotvRepository
     )
     {
         var file = environment.WebRootFileProvider.GetFileInfo("screen/screen.html");
@@ -105,13 +146,19 @@ internal static class ScreenEndpointsExtensions
         var query = context.Request.Query;
         uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
         var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
-        var source = assignments.Resolve(route, query["movieid"], mapId, channel);
+        var (effectiveRoute, movieId) = await ResolveRoomTvAsync(
+            route,
+            query,
+            nicotvRepository,
+            context.RequestAborted
+        );
+        var source = assignments.Resolve(effectiveRoute, movieId, mapId, channel);
 
         // A room TV never needs the page to poll: the client re-navigates it on every assignment
         // change (movie set, channel switch, room re-entry). live-watch (the Stage) is pushed
         // too: /screen sends it notify_nicolive_reload (CmdExecHandler). A /channel-screen is a
         // town screen (confirmed on Akihabara) with neither guarantee, so it alone keeps polling.
-        var noPoll = route is "room-tv" or "live-watch";
+        var noPoll = effectiveRoute is "room-tv" or "live-watch";
         var titleSuffix =
             (noPoll ? ";nopoll=1" : "")
             + (source is not null ? $";src={WebUtility.HtmlEncode(source)}" : "");

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace aisp.Server;
+
+/// <summary>
+/// Pages for the in-game screens. The client's displays are IE controls navigated to URLs it
+/// builds from its own templates; the launcher's hook rewrites those to these paths, keeping the
+/// distinction between them, passes the client's parameters along as the query string, and adds
+/// the map and channel the client is on (map=, ch=), which the URL itself does not carry:
+///   /ai-sp/room-tv?movieid=...            a TV given a movie id (動画指定)
+///   /ai-sp/channel-screen?tvid=..&chid=.. a TV or town screen on a channel
+///   /ai-sp/live-watch?liveid=...          the Nico Live billboard
+///   /ai-sp/screen?url=...                 anything else the client asked aisp.jp for
+/// All of them serve the same page: it shows which route and parameters it got, implements the
+/// script contract the client drives (external_nico_0.ext_*), and publishes volume and mute in
+/// its title for the hook.
+/// </summary>
+internal static class ScreenEndpointsExtensions
+{
+    private static readonly string[] Routes = ["room-tv", "channel-screen", "live-watch", "screen"];
+
+    internal static WebApplication MapScreenEndpoints(this WebApplication app)
+    {
+        foreach (var route in Routes)
+            app.MapGet(
+                "/ai-sp/" + route,
+                (HttpContext context, IWebHostEnvironment environment) =>
+                    ServePage(context, environment)
+            );
+        return app;
+    }
+
+    private static async Task<IResult> ServePage(
+        HttpContext context,
+        IWebHostEnvironment environment
+    )
+    {
+        var file = environment.WebRootFileProvider.GetFileInfo("screen/screen.html");
+        if (!file.Exists || file.PhysicalPath is null)
+            return Results.NotFound();
+
+        var html = await File.ReadAllTextAsync(file.PhysicalPath, context.RequestAborted);
+
+        // The control fetches a page once per screen and the client keeps drawing that document,
+        // so nothing here should ever be cached or redirected after it loaded.
+        context.Response.Headers.CacheControl = "no-store";
+        return Results.Content(html, "text/html; charset=utf-8");
+    }
+}

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -216,10 +216,15 @@ internal static class ScreenEndpointsExtensions
         // Stage) is pushed too: both /screen and /channel on a map it is bound to send it
         // notify_nicolive_reload (CmdExecHandler). A /channel-screen that did not resolve to a
         // room TV is a town screen (confirmed on Akihabara) with neither guarantee, so it alone
-        // keeps polling.
-        var noPoll = effectiveRoute is "room-tv" or "live-watch";
+        // keeps polling. roomtv is a separate, narrower flag: only a genuine room TV shows the
+        // comment overlay, never the Stage or a town screen, no matter what the page is told by
+        // ext_setCommentVisible; the page cannot tell a room TV from anything else on its own,
+        // only the server (map lookup) can.
+        var isRoomTv = effectiveRoute == "room-tv";
+        var noPoll = isRoomTv || effectiveRoute == "live-watch";
         var titleSuffix =
-            (noPoll ? ";nopoll=1" : "")
+            (isRoomTv ? ";roomtv=1" : "")
+            + (noPoll ? ";nopoll=1" : "")
             + (source is not null ? $";src={WebUtility.HtmlEncode(source)}" : "");
 
         var html = await File.ReadAllTextAsync(file.PhysicalPath, context.RequestAborted);

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using aisp.Common.DAL.Repositories;
 using aisp.Common.Game;
+using aisp.Network;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -58,7 +59,7 @@ internal static class ScreenEndpointsExtensions
                     ? parsedTvId
                     : null;
                 var action = query["action"].ToString();
-                var (route, movieId) = await ResolveRoomTvAsync(
+                var (route, movieId, _) = await ResolveRoomTvAsync(
                     query["route"].ToString(),
                     query,
                     nicotvRepository,
@@ -114,7 +115,7 @@ internal static class ScreenEndpointsExtensions
                         "screen-source poll {Query}",
                         context.Request.QueryString.Value
                     );
-                var (route, movieId) = await ResolveRoomTvAsync(
+                var (route, movieId, _) = await ResolveRoomTvAsync(
                     query["route"].ToString(),
                     query,
                     nicotvRepository,
@@ -133,7 +134,9 @@ internal static class ScreenEndpointsExtensions
     /// appends to its own Notify* broadcasts and get-info/open responses): when it does, the
     /// database's own movie and channel state for that Nicotv is authoritative over whatever the
     /// client's URL still says, and the route becomes room-tv so
-    /// <see cref="ScreenAssignments.Resolve"/> plays it.
+    /// <see cref="ScreenAssignments.Resolve"/> plays it. The same row carries the TV's comment
+    /// overlay default, which the page starts from (the client itself never sets it, see
+    /// AreaNicotvOpenByFurnitureHandler).
     ///
     /// channel-screen's own tvid= query parameter is a different thing: the client's own word,
     /// not ours. It is the channel number itself (0 through 4, and 0 is a real channel, not "no
@@ -144,7 +147,11 @@ internal static class ScreenEndpointsExtensions
     /// channel:&lt;n&gt;, the same way the database lookup above does for a channel-tuned Nicotv
     /// row.
     /// </summary>
-    private static async Task<(string Route, string? MovieId)> ResolveRoomTvAsync(
+    private static async Task<(
+        string Route,
+        string? MovieId,
+        bool CommentsVisible
+    )> ResolveRoomTvAsync(
         string route,
         IQueryCollection query,
         INicotvRepository nicotvRepository,
@@ -161,7 +168,11 @@ internal static class ScreenEndpointsExtensions
                 : !string.IsNullOrEmpty(nicotv.MovieId) ? nicotv.MovieId
                 : nicotv.ChannelId != 0 ? $"channel:{nicotv.ChannelId}"
                 : null;
-            return ("room-tv", content is null ? null : $"{content} n:{nicotvId}");
+            return (
+                "room-tv",
+                content is null ? null : $"{content} n:{nicotvId}",
+                nicotv?.CommentVisibility == NicotvCommentVisibility.Visible
+            );
         }
 
         if (
@@ -170,9 +181,9 @@ internal static class ScreenEndpointsExtensions
             && MyRoomInfo.IsMyRoomMap(mapId)
             && uint.TryParse(query["tvid"], out var channelNumber)
         )
-            return ("room-tv", $"channel:{channelNumber}");
+            return ("room-tv", $"channel:{channelNumber}", false);
 
-        return (route, query["movieid"]);
+        return (route, query["movieid"], false);
     }
 
     private static async Task<IResult> ServePage(
@@ -202,7 +213,7 @@ internal static class ScreenEndpointsExtensions
         uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
         var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
         uint? requestTvId = uint.TryParse(query["tvid"], out var parsedTvId) ? parsedTvId : null;
-        var (effectiveRoute, movieId) = await ResolveRoomTvAsync(
+        var (effectiveRoute, movieId, commentsVisible) = await ResolveRoomTvAsync(
             route,
             query,
             nicotvRepository,
@@ -219,12 +230,15 @@ internal static class ScreenEndpointsExtensions
         // keeps polling. roomtv is a separate, narrower flag: only a genuine room TV shows the
         // comment overlay, never the Stage or a town screen, no matter what the page is told by
         // ext_setCommentVisible; the page cannot tell a room TV from anything else on its own,
-        // only the server (map lookup) can.
+        // only the server (map lookup) can. comment=1 is the TV's own default for the overlay
+        // (off when absent): the client never sets it, so the page must start from the server's
+        // value, and it starts over on every re-navigation.
         var isRoomTv = effectiveRoute == "room-tv";
         var noPoll = isRoomTv || effectiveRoute == "live-watch";
         var titleSuffix =
             (isRoomTv ? ";roomtv=1" : "")
             + (noPoll ? ";nopoll=1" : "")
+            + (commentsVisible ? ";comment=1" : "")
             + (source is not null ? $";src={WebUtility.HtmlEncode(source)}" : "");
 
         var html = await File.ReadAllTextAsync(file.PhysicalPath, context.RequestAborted);

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -35,8 +35,9 @@ internal static class ScreenEndpointsExtensions
                     HttpContext context,
                     IWebHostEnvironment environment,
                     ScreenAssignments assignments,
-                    INicotvRepository nicotvRepository
-                ) => ServePage(route, context, environment, assignments, nicotvRepository)
+                    INicotvRepository nicotvRepository,
+                    ILoggerFactory loggers
+                ) => ServePage(route, context, environment, assignments, nicotvRepository, loggers)
             );
         // Moves a video's shared timeline for everyone; the reply is the new source line. The
         // page does not use it yet: the client calls its ext_play/ext_pause around its own
@@ -53,6 +54,9 @@ internal static class ScreenEndpointsExtensions
                 var query = context.Request.Query;
                 uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
                 var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
+                uint? requestTvId = uint.TryParse(query["tvid"], out var parsedTvId)
+                    ? parsedTvId
+                    : null;
                 var action = query["action"].ToString();
                 var (route, movieId) = await ResolveRoomTvAsync(
                     query["route"].ToString(),
@@ -77,7 +81,12 @@ internal static class ScreenEndpointsExtensions
                     );
                 context.Response.Headers.CacheControl = "no-store";
                 return Results.Json(
-                    new { applied, src = assignments.Resolve(route, movieId, mapId, channel) ?? "" }
+                    new
+                    {
+                        applied,
+                        src = assignments.Resolve(route, movieId, mapId, channel, requestTvId)
+                            ?? "",
+                    }
                 );
             }
         );
@@ -87,19 +96,31 @@ internal static class ScreenEndpointsExtensions
             async (
                 HttpContext context,
                 ScreenAssignments assignments,
-                INicotvRepository nicotvRepository
+                INicotvRepository nicotvRepository,
+                ILoggerFactory loggers
             ) =>
             {
                 var query = context.Request.Query;
                 uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
                 var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
+                uint? requestTvId = uint.TryParse(query["tvid"], out var parsedTvId)
+                    ? parsedTvId
+                    : null;
+                // TEMPORARY: log the raw query so we can see exactly what the client is polling
+                // with. Remove once the tvid round-trip is confirmed end to end.
+                loggers
+                    .CreateLogger("aisp.Server.ScreenEvents")
+                    .LogInformation(
+                        "screen-source poll {Query}",
+                        context.Request.QueryString.Value
+                    );
                 var (route, movieId) = await ResolveRoomTvAsync(
                     query["route"].ToString(),
                     query,
                     nicotvRepository,
                     context.RequestAborted
                 );
-                var source = assignments.Resolve(route, movieId, mapId, channel);
+                var source = assignments.Resolve(route, movieId, mapId, channel, requestTvId);
                 context.Response.Headers.CacheControl = "no-store";
                 return Results.Json(new { src = source ?? "" });
             }
@@ -109,10 +130,19 @@ internal static class ScreenEndpointsExtensions
 
     /// <summary>
     /// A room TV may identify the furniture it's for as an n: tag on movieid (the tag the server
-    /// appends to its own Notify* broadcasts and get-info/open responses): when it does,
-    /// the database's own movie state for that Nicotv is authoritative over whatever the
+    /// appends to its own Notify* broadcasts and get-info/open responses): when it does, the
+    /// database's own movie and channel state for that Nicotv is authoritative over whatever the
     /// client's URL still says, and the route becomes room-tv so
     /// <see cref="ScreenAssignments.Resolve"/> plays it.
+    ///
+    /// channel-screen's own tvid= query parameter is a different thing: the client's own word,
+    /// not ours. It is the channel number itself (0 through 4, and 0 is a real channel, not "no
+    /// channel"), sent when a room TV is tuned to a channel rather than a typed movie, including
+    /// on room re-entry. It is only a channel reference on a MyRoom map: a town map's own screens
+    /// (confirmed on Akihabara) send a tvid= too, and treating that as a channel would override
+    /// the town screen's own /screen assignment. So only a room TV's tvid= indirects through
+    /// channel:&lt;n&gt;, the same way the database lookup above does for a channel-tuned Nicotv
+    /// row.
     /// </summary>
     private static async Task<(string Route, string? MovieId)> ResolveRoomTvAsync(
         string route,
@@ -124,9 +154,23 @@ internal static class ScreenEndpointsExtensions
         if (ScreenAssignments.TryGetNicotvId(query["movieid"], out var nicotvId))
         {
             var nicotv = await nicotvRepository.GetByIdAsync(nicotvId, ct);
-            var content = string.IsNullOrEmpty(nicotv?.MovieId) ? null : nicotv.MovieId;
+            // A movie id and a channel are exclusive on a Nicotv row (see NicotvRepository), so
+            // at most one of these is ever set.
+            var content =
+                nicotv is null ? null
+                : !string.IsNullOrEmpty(nicotv.MovieId) ? nicotv.MovieId
+                : nicotv.ChannelId != 0 ? $"channel:{nicotv.ChannelId}"
+                : null;
             return ("room-tv", content is null ? null : $"{content} n:{nicotvId}");
         }
+
+        if (
+            route == "channel-screen"
+            && uint.TryParse(query["map"], out var mapId)
+            && MyRoomInfo.IsMyRoomMap(mapId)
+            && uint.TryParse(query["tvid"], out var channelNumber)
+        )
+            return ("room-tv", $"channel:{channelNumber}");
 
         return (route, query["movieid"]);
     }
@@ -136,28 +180,43 @@ internal static class ScreenEndpointsExtensions
         HttpContext context,
         IWebHostEnvironment environment,
         ScreenAssignments assignments,
-        INicotvRepository nicotvRepository
+        INicotvRepository nicotvRepository,
+        ILoggerFactory loggers
     )
     {
         var file = environment.WebRootFileProvider.GetFileInfo("screen/screen.html");
         if (!file.Exists || file.PhysicalPath is null)
             return Results.NotFound();
 
+        // TEMPORARY: log the raw query of the page navigation itself. Remove once the tvid
+        // round-trip is confirmed end to end.
+        loggers
+            .CreateLogger("aisp.Server.ScreenEvents")
+            .LogInformation(
+                "screen page GET /ai-sp/{Route}{Query}",
+                route,
+                context.Request.QueryString.Value
+            );
+
         var query = context.Request.Query;
         uint? mapId = uint.TryParse(query["map"], out var parsedMap) ? parsedMap : null;
         var channel = int.TryParse(query["ch"], out var parsedChannel) ? parsedChannel : 0;
+        uint? requestTvId = uint.TryParse(query["tvid"], out var parsedTvId) ? parsedTvId : null;
         var (effectiveRoute, movieId) = await ResolveRoomTvAsync(
             route,
             query,
             nicotvRepository,
             context.RequestAborted
         );
-        var source = assignments.Resolve(effectiveRoute, movieId, mapId, channel);
+        var source = assignments.Resolve(effectiveRoute, movieId, mapId, channel, requestTvId);
 
-        // A room TV never needs the page to poll: the client re-navigates it on every assignment
-        // change (movie set, channel switch, room re-entry). live-watch (the Stage) is pushed
-        // too: /screen sends it notify_nicolive_reload (CmdExecHandler). A /channel-screen is a
-        // town screen (confirmed on Akihabara) with neither guarantee, so it alone keeps polling.
+        // A genuine room TV (whether reached as /room-tv, or as /channel-screen resolved onto
+        // one by a MyRoom map above) never needs the page to poll: the client re-navigates it on
+        // every assignment change (movie set, channel switch, room re-entry). live-watch (the
+        // Stage) is pushed too: both /screen and /channel on a map it is bound to send it
+        // notify_nicolive_reload (CmdExecHandler). A /channel-screen that did not resolve to a
+        // room TV is a town screen (confirmed on Akihabara) with neither guarantee, so it alone
+        // keeps polling.
         var noPoll = effectiveRoute is "room-tv" or "live-watch";
         var titleSuffix =
             (noPoll ? ";nopoll=1" : "")

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -62,11 +62,13 @@ body.tv #comments{top:36px}
 <iframe id="frame" style="position:absolute;left:0;top:0;width:0;height:0;border:0;display:none" frameborder="0" scrolling="no"></iframe>
 <iframe id="banner" style="position:absolute;left:0;top:0;width:0;height:0;border:0;display:none" frameborder="0" scrolling="no"></iframe>
 <div id="external_nico_0"></div>
-<!-- The client reads this element's .value for "value=<state> " (space-terminated) to learn the
-     player state, and gates ext_setCommentVisible's local flush on it reading playing or paused.
-     A plain div's .value is undefined, so this has to be a real form control, not matching
-     text as innerHTML. -->
-<input id="statusForm" type="text" readonly value="value=playing (statusForm)" style="position:absolute;left:9px;top:580px;font-size:11px;color:#888;border:0;background:transparent;padding:0" />
+<!-- The client reads this element's innerHTML (IHTMLElement::get_innerHTML, confirmed in the
+     binary's statusForm parser) for "value=<state> " (space-terminated) to learn the player
+     state: load, playing, paused, buffering, stopped, end, seeking. Anything else, including
+     an <input>, whose innerHTML is empty, parses as state 0, and the client crashes a few
+     seconds after a TV page that never leaves that state. So this stays a plain element with
+     the token in its text, never a form control. -->
+<div id="statusForm" style="position:absolute;left:9px;top:580px;font-size:11px;color:#888">value=playing (statusForm)</div>
 <div id="outside">This line is outside every crop rectangle and should never be visible in game.</div>
 <script>
 (function(){
@@ -196,9 +198,9 @@ body.tv #comments{top:36px}
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
     document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
       +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');
-    // The client forwards volume while the state is playing or paused, and only flushes a
-    // pending comment-visibility toggle then too; it reads the word from .value here.
-    var sf=$('statusForm'); if(sf) sf.value='value='+(tl.paused||state.paused?'paused':'playing')+' (statusForm)';
+    // The client forwards volume, and flushes a pending comment-visibility toggle, only while
+    // the state is playing or paused; it reads the word from this element's innerHTML.
+    var sf=$('statusForm'); if(sf) sf.innerHTML='value='+(tl.paused||state.paused?'paused':'playing')+' (statusForm)';
   }
   // "title": a title card, "aisp-emu" centred in each panel on a dark background ('all'), or
   // on the Stage banner alone ('top') while the main panel plays something and nothing else

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -45,8 +45,10 @@ body.tv #comments{top:36px}
     <div id="calls">calls from the client appear here</div>
   </div>
 </div>
-<!-- A page source (http/https) is shown in the frame; stream sources go to the hook. -->
+<!-- A page source (http/https) or a main: frame page is shown in the first frame, a banner: page
+     in the second; stream sources go to the hook. -->
 <iframe id="frame" style="position:absolute;left:0;top:0;width:0;height:0;border:0;display:none" frameborder="0" scrolling="no"></iframe>
+<iframe id="banner" style="position:absolute;left:0;top:0;width:0;height:0;border:0;display:none" frameborder="0" scrolling="no"></iframe>
 <div id="external_nico_0"></div>
 <!-- The client reads this element's .value for "value=<state> " (space-terminated) to learn the
      player state, and gates ext_setCommentVisible's local flush on it reading playing or paused.
@@ -98,23 +100,72 @@ body.tv #comments{top:36px}
   // instead. A town screen (a channel-screen, Akihabara confirmed) has neither guarantee, so it
   // is the one case left polling.
   var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
-  var frame=$('frame');
+  var frame=$('frame'), bannerFrame=$('banner');
   function isPage(v){ return /^https?:\/\//i.test(v); }
-  // The main source goes to the main panel: stream sources are published for the hook; pages
-  // are framed here.
+  // "<main> [main:<url>] [banner:<url>] [<url>] [box:x/y/w/h] ...": the main source goes to the
+  // main panel; main:<url> is a frame page under the whole main panel (the hook paints the video
+  // box over it); banner:<url> is a page for the Stage banner strip. The raw form is a bare
+  // URL word: with a box or key it is a frame page under the whole crop, in crop coordinates,
+  // otherwise the Stage banner. Stream sources are published for the hook; pages are framed here.
   function mainOf(v){ return (v||'').split(' ')[0]; }
+  function wordOf(v,name){ var w=(v||'').split(' '), re=new RegExp('^'+name+':(https?://.+)$','i'); for(var i=1;i<w.length;i++){ var m=re.exec(w[i]); if(m) return m[1]; } return ''; }
+  function mainPageOf(v){ return wordOf(v,'main'); }
+  function bannerOf(v){ return wordOf(v,'banner'); }
+  function rawPageOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++) if(isPage(w[i])) return w[i]; return ''; }
+  function hasBox(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++) if(/^box:/i.test(w[i])) return true; return false; }
   // The main panel, in crop coordinates: a TV shows all of its crop, the Stage wall its main LED.
   var panel=isLive?[7,65,543,382]:[0,0,486,343];
+  function boxOf(v){
+    var w=(v||'').split(' ');
+    for(var i=1;i<w.length;i++){ var m=/^box:(\d+)\/(\d+)\/(\d+)\/(\d+)$/i.exec(w[i]); if(m) return [+m[1],+m[2],+m[3],+m[4]]; }
+    return null;
+  }
+  // The video box: where the hook paints a stream, in crop coordinates. Without a box word it
+  // is the whole main panel. A box word is in crop coordinates, unless a main: frame page is
+  // given: then it is relative to the main panel, the way the frame page sees it, and the crop
+  // form is worked out here. Returns {crop:[x,y,w,h] for the hook, rel:[x,y,w,h] for the page}.
+  function geometry(v){
+    var raw=boxOf(v), mp=mainPageOf(v);
+    if(!raw) return { crop:panel, rel:[0,0,panel[2],panel[3]] };
+    if(mp) return { crop:[panel[0]+raw[0],panel[1]+raw[1],raw[2],raw[3]], rel:raw };
+    return { crop:raw, rel:[raw[0]-panel[0],raw[1]-panel[1],raw[2],raw[3]] };
+  }
+  // key or key:RRGGBB: the hook fills only pixels of exactly that colour inside the box with
+  // video, so page content drawn over it stays on top. Bare key is the DirectDraw overlay key,
+  // the near-black RGB 16,0,16.
+  function keyOf(v){
+    var w=(v||'').split(' ');
+    for(var i=1;i<w.length;i++){ if(/^key$/i.test(w[i])) return '100010'; var m=/^key:([0-9a-f]{6})$/i.exec(w[i]); if(m) return m[1].toLowerCase(); }
+    return '';
+  }
+  // crop:sw/sh:cx/cy: the hook renders the picture at sw x sh and paints the box-sized window
+  // starting at cx,cy of it (zoom in, or cut a region out). For electron: sw/sh is the browser's
+  // layout viewport. Published as crop=sw,sh,cx,cy.
+  function cropOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^crop:(\d+)\/(\d+):(\d+)\/(\d+)$/i.exec(w[i]); if(m) return [+m[1],+m[2],+m[3],+m[4]].join(','); } return ''; }
+  // scrollx:N, scrolly:N, or scroll:x/y: document offset the off-screen browser (electron:) enforces.
+  // Null when no scroll extra is present (the hook then shows scrollbars again).
+  function scrollOf(v){
+    var x=0,y=0,set=false,w=(v||'').split(' ');
+    for(var i=1;i<w.length;i++){
+      var mx=/^scrollx:(-?\d+)$/i.exec(w[i]); if(mx){ x=+mx[1]; set=true; }
+      var my=/^scrolly:(-?\d+)$/i.exec(w[i]); if(my){ y=+my[1]; set=true; }
+      var m=/^scroll:(-?\d+)\/(-?\d+)$/i.exec(w[i]); if(m){ x=+m[1]; y=+m[2]; set=true; }
+    }
+    return set?[x,y]:null;
+  }
+  // scale:N: Chromium zoom for electron: (1 = 100%). Not a texture stretch.
+  function scaleOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^scale:([0-9]*\.?[0-9]+)$/i.exec(w[i]); if(m){ var n=+m[1]; if(n>=0.1&&n<=8) return n; } } return 0; }
   function publish(){
-    var m=mainOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+(stream?';src='+m:'');
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(stream?';src='+m:'');
     // The client forwards volume while the state is playing or paused, and only flushes a
     // pending comment-visibility toggle then too; it reads the word from .value here.
     var sf=$('statusForm'); if(sf) sf.value='value='+(state.paused?'paused':'playing')+' (statusForm)';
   }
   // "title": a title card, "aisp-emu" centred in each panel on a dark background ('all'), or
-  // on the Stage banner alone ('top') while the main panel plays something.
+  // on the Stage banner alone ('top') while the main panel plays something and nothing else
+  // claims the banner.
   var cards=[];
   function showTitleCard(mode){
     for(var i=0;i<cards.length;i++) box.removeChild(cards[i]);
@@ -129,6 +180,23 @@ body.tv #comments{top:36px}
       c.appendChild(t);
       box.appendChild(c); cards.push(c);
     }
+  }
+  var boxFrame=null, keyFill=null;
+  function showBoxFrame(b,k){
+    if(boxFrame){ box.removeChild(boxFrame); boxFrame=null; }
+    if(keyFill){ box.removeChild(keyFill); keyFill=null; }
+    if(!b) return;
+    // Without a frame page the shell paints the key colour itself, or nothing matches.
+    if(k){
+      keyFill=document.createElement('div'); keyFill.style.position='absolute';
+      keyFill.style.left=b[0]+'px'; keyFill.style.top=b[1]+'px'; keyFill.style.width=b[2]+'px'; keyFill.style.height=b[3]+'px';
+      keyFill.style.background='#'+k; box.appendChild(keyFill);
+    }
+    if(b[0]===panel[0]&&b[1]===panel[1]&&b[2]===panel[2]&&b[3]===panel[3]) return;
+    boxFrame=document.createElement('div'); boxFrame.style.position='absolute';
+    boxFrame.style.left=(b[0]-4)+'px'; boxFrame.style.top=(b[1]-4)+'px'; boxFrame.style.width=(b[2]+8)+'px'; boxFrame.style.height=(b[3]+8)+'px';
+    boxFrame.style.border='4px solid #ffd166'; boxFrame.style.boxSizing='content-box';
+    box.appendChild(boxFrame);
   }
   // While a real source is up, the page is a blank black base under it.
   function showDiagnostics(on){
@@ -178,25 +246,45 @@ body.tv #comments{top:36px}
     }
     box.appendChild(rectsLayer);
   }
+  // The frame page learns where the video box is inside it, the size it fills and the key
+  // colour, if any. For main: the box is relative to the main panel, which is the frame's own
+  // size; for the raw whole-crop form both are in crop coordinates.
+  function withParams(url,b,w,h,k){
+    return url+(url.indexOf('?')<0?'?':'&')+'box='+b.join('/')+'&crop='+w+'/'+h+(isLive?'&kind=live':'&kind=tv')+(k?'&key='+k:'');
+  }
   function place(f,x,y,w,h,url){
     f.style.left=x+'px'; f.style.top=y+'px'; f.style.width=w+'px'; f.style.height=h+'px'; f.style.display='block';
     if(f.src!==url) f.src=url;
   }
   function hide(f){ f.style.display='none'; if(f.src) f.src='about:blank'; }
   function applySource(){
-    var m=mainOf(src);
-    var ox=isLive?0:9, oy=isLive?0:15; // the crop inside the page
+    var m=mainOf(src), mp=mainPageOf(src), bn=bannerOf(src), raw=rawPageOf(src), g=geometry(src), vb=g.crop, k=keyOf(src);
+    var ox=isLive?0:9, oy=isLive?0:15, cw=isLive?950:486, ch=isLive?520:343; // the crop inside the page
+    var rawFrame=raw&&!isPage(m)&&(hasBox(src)||!!k), rawBanner=raw&&!rawFrame;
+    // The built-in gold frame and key fill are only for a box without a frame page: a frame
+    // page paints around (and, keyed, over) the video itself.
+    showBoxFrame(m&&!isPage(m)&&m!=='blank'&&!mp&&!rawFrame?vb:null, k);
     showGrid(m==='calibrate');
     showRects(/^c:/i.test(m)?m.substring(2):null);
     var diagnostic = !m || m==='calibrate' || /^c:/i.test(m);
     showDiagnostics(diagnostic);
     // A banner left free by a playing main panel shows the title card rather than nothing.
-    var topFree=isLive && m && m!=='title' && m!=='blank' && !diagnostic;
+    var topFree=isLive && m && m!=='title' && m!=='blank' && !diagnostic && !bn && !raw;
     showTitleCard(m==='title'?'all':(topFree?'top':null));
     if(isPage(m))
-      place(frame, ox+panel[0], oy+panel[1], panel[2], panel[3], m); // a page as the source: over the main panel
+      place(frame, ox+vb[0], oy+vb[1], vb[2], vb[3], m); // a page as the source: over the video box
+    else if(mp)
+      place(frame, ox+panel[0], oy+panel[1], panel[2], panel[3], withParams(mp,g.rel,panel[2],panel[3],k)); // under the whole main panel
+    else if(rawFrame)
+      place(frame, ox, oy, cw, ch, withParams(raw,vb,cw,ch,k)); // the raw form: under the whole crop
     else
       hide(frame);
+    if(isLive && bn)
+      place(bannerFrame, 7, 7, 543, 53, bn);
+    else if(isLive && rawBanner)
+      place(bannerFrame, 7, 7, 543, 53, raw);
+    else
+      hide(bannerFrame);
     publish();
   }
   function updateComments(){

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>aisp:vol=100;mute=0</title>
+<style>
+html,body{margin:0;padding:0;background:#fff;color:#000;font-family:Arial,sans-serif;overflow:hidden}
+/* The client copies a fixed rectangle out of the rendered page: 486x343 at (9,15) for a room
+   TV or channel screen, 950x520 at flvplayer_container's origin for live-watch. The launcher
+   hook paints a decoded stream into the video box of that crop; everything else here is what
+   the panels show of the page itself. */
+#navi{position:absolute;left:0;top:0;width:1024px;height:0}
+#flvplayer_container{position:absolute;background:#000;color:#fff;overflow:hidden}
+body.tv #flvplayer_container{left:9px;top:15px;width:486px;height:343px}
+body.live #flvplayer_container{left:0;top:0;width:950px;height:520px}
+/* The Stage wall shows two windows onto the crop, measured in game with /screen c: outlines
+   (2026-09-03): the banner is page (7,7)-(550,60), the main LED (7,65)-(550,447). A TV shows its
+   whole 486x343 crop. */
+.led{position:absolute;background:#1a1a2e;overflow:hidden}
+body.live #led-top{left:7px;top:7px;width:543px;height:53px}
+body.live #led-main{left:7px;top:65px;width:543px;height:382px}
+body.tv #led-top{display:none}
+body.tv #led-main{left:0;top:0;width:486px;height:343px}
+#title{position:absolute;left:12px;top:8px;font-size:22px;font-weight:bold;color:#ffd166;white-space:nowrap}
+body.tv #title{font-size:18px;top:6px}
+#meta{position:absolute;left:12px;top:10px;font-size:13px;color:#cfe;line-height:18px}
+body.tv #meta{top:32px}
+#calls{position:absolute;left:12px;bottom:8px;width:90%;height:90px;font-size:12px;color:#fc9;overflow:hidden}
+#pulse{position:absolute;right:12px;top:10px;width:24px;height:24px;background:#f80}
+/* Dummy feedback for ext_setCommentVisible: no real comment data, just a small on/off indicator. */
+#comments{position:absolute;right:12px;top:40px;font-size:12px;color:#8f8}
+body.tv #comments{top:36px}
+#outside{position:absolute;left:9px;top:600px;font-size:12px;color:#888}
+.ret{position:absolute;left:520px;font-size:12px;color:#00f}
+.corner{position:absolute;width:12px;height:12px;background:#f80}
+.panel{position:absolute;outline:2px solid #f80}
+.panel .lab{position:absolute;left:4px;top:2px;font-size:11px;color:#f80}
+</style></head><body>
+<div id="navi"></div>
+<div id="flvplayer_container">
+  <div id="led-top" class="led"><div id="title">aisp-emu screen</div><div id="pulse"></div></div>
+  <div id="led-main" class="led">
+    <div id="meta">loading</div>
+    <div id="comments">💬 on</div>
+    <div id="calls">calls from the client appear here</div>
+  </div>
+</div>
+<div id="external_nico_0"></div>
+<!-- The client reads this element's .value for "value=<state> " (space-terminated) to learn the
+     player state, and gates ext_setCommentVisible's local flush on it reading playing or paused.
+     A plain div's .value is undefined, so this has to be a real form control, not matching
+     text as innerHTML. -->
+<input id="statusForm" type="text" readonly value="value=playing (statusForm)" style="position:absolute;left:9px;top:580px;font-size:11px;color:#888;border:0;background:transparent;padding:0" />
+<div id="outside">This line is outside every crop rectangle and should never be visible in game.</div>
+<script>
+(function(){
+  function $(id){ return document.getElementById(id); }
+  var path=(window.location.pathname||'').replace(/^.*\//,'');
+  var kind={ 'room-tv':'room TV', 'channel-screen':'channel screen', 'live-watch':'live billboard' }[path]||'unknown screen';
+  var isLive=path==='live-watch';
+  document.body.className=isLive?'live':'tv';
+  var box=$('flvplayer_container'), main=$('led-main');
+  if(!isLive){ main.appendChild($('title')); main.appendChild($('pulse')); }
+  function corners(rects){
+    for(var r=0;r<rects.length;r++){
+      var x=rects[r][0], y=rects[r][1], w=rects[r][2], h=rects[r][3], n=rects[r][4];
+      if(n){
+        var p=document.createElement('div'); p.className='panel';
+        p.style.left=x+'px'; p.style.top=y+'px'; p.style.width=w+'px'; p.style.height=h+'px';
+        var lab=document.createElement('div'); lab.className='lab'; lab.innerHTML=n; p.appendChild(lab);
+        box.appendChild(p);
+      }
+      var cs=[[x,y],[x+w-12,y],[x,y+h-12],[x+w-12,y+h-12]];
+      for(var j=0;j<cs.length;j++){
+        var c=document.createElement('div'); c.className='corner';
+        c.style.left=cs[j][0]+'px'; c.style.top=cs[j][1]+'px'; box.appendChild(c);
+      }
+    }
+  }
+  // Corner markers on the boxes the panels actually show.
+  corners(isLive?[[7,7,543,53,'top'],[7,65,543,382,'main']]:[[0,0,486,343,'']]);
+  var q={}, search=(window.location.search||'').substring(1).split('&');
+  for(var i=0;i<search.length;i++){ if(!search[i]) continue; var kv=search[i].split('='); try{ q[decodeURIComponent(kv[0])]=decodeURIComponent((kv[1]||'').replace(/\+/g,' ')); }catch(e){ q[kv[0]]=kv[1]; } }
+  var params=[]; for(var k in q) if(q.hasOwnProperty(k)) params.push(k+'='+q[k]);
+  var meta=$('meta'), calls=$('calls'), ext=$('external_nico_0'), pulse=$('pulse');
+  var mode=document.documentMode||'none', t0=new Date().getTime(), log=[];
+  var state={ volume:100, mute:false, repeat:true, comment:true, playhead:0, total:0, paused:false };
+  function note(s){
+    log.unshift(s); if(log.length>6) log.length=6; calls.innerHTML=log.join('<br>');
+  }
+  // The launcher hook reads volume and mute from the title, which must survive every update.
+  function publish(){
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0);
+    // The client forwards volume while the state is playing or paused, and only flushes a
+    // pending comment-visibility toggle then too; it reads the word from .value here.
+    var sf=$('statusForm'); if(sf) sf.value='value='+(state.paused?'paused':'playing')+' (statusForm)';
+  }
+  function updateComments(){
+    var el=$('comments'); if(!el) return;
+    el.textContent=state.comment?'💬 on':'💬 off';
+    el.style.color=state.comment?'#8f8':'#888';
+  }
+  updateComments();
+  var retTop=600;
+  // Getters hand back their value through an element the client reads by id and then removes.
+  function ret(name,value){
+    var d=document.createElement('div'); d.id=name; d.className='ret'; d.style.top=(retTop+=14)+'px';
+    d.innerText=String(value); d.value=String(value); document.body.appendChild(d); return value;
+  }
+  // The client's play/pause toggle is a single ext_play(bool), called with whether it is now
+  // playing (false for pause); there is no separate ext_pause in real use.
+  ext.ext_play=function(playing){ note('ext_play('+playing+')'); state.paused=!playing; publish(); };
+  ext.ext_pause=function(){ note('ext_pause'); state.paused=true; publish(); };
+  ext.ext_stop=function(){ note('ext_stop'); state.paused=true; publish(); };
+  ext.ext_setMute=function(m){ note('ext_setMute '+m); state.mute=!!m; publish(); };
+  ext.ext_setPlayheadTime=function(t){ note('ext_setPlayheadTime '+t); state.playhead=Number(t)||0; };
+  ext.ext_setVolume=function(n){ note('ext_setVolume '+n); state.volume=Math.max(0,Math.min(100,Math.round(Number(n)))); publish(); };
+  ext.ext_setCommentVisible=function(b){ note('ext_setCommentVisible '+b); state.comment=!!b; updateComments(); };
+  ext.ext_setRepeat=function(b){ note('ext_setRepeat '+b); state.repeat=!!b; };
+  ext.ext_isMute=function(r){ note('ext_isMute -> '+r); return ret(r, state.mute?1:0); };
+  ext.ext_getVolume=function(r){ note('ext_getVolume -> '+r); return ret(r, state.volume); };
+  ext.ext_isCommentVisible=function(r){ note('ext_isCommentVisible -> '+r); return ret(r, state.comment?1:0); };
+  ext.ext_isRepeat=function(r){ note('ext_isRepeat -> '+r); return ret(r, state.repeat?1:0); };
+  ext.ext_getPlayheadTime=function(r){ note('ext_getPlayheadTime -> '+r); return ret(r, Math.floor((new Date().getTime()-t0)/1000)); };
+  ext.ext_getTotalTime=function(r){ note('ext_getTotalTime -> '+r); return ret(r, state.total); };
+  publish();
+  setInterval(function(){
+    var s=Math.floor((new Date().getTime()-t0)/1000);
+    meta.innerHTML=kind+' ('+path+')<br>'+(params.length?params.join(' &nbsp; '):'no parameters')+'<br>mode: '+mode+' &nbsp; clock: '+s+'s &nbsp; volume: '+state.volume+(state.mute?' (muted)':'');
+    pulse.style.background=(s%2)?'#f80':'#0cf';
+  },250);
+})();
+</script>
+</body></html>

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -155,10 +155,17 @@ body.tv #comments{top:36px}
   }
   // scale:N: Chromium zoom for electron: (1 = 100%). Not a texture stretch.
   function scaleOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^scale:([0-9]*\.?[0-9]+)$/i.exec(w[i]); if(m){ var n=+m[1]; if(n>=0.1&&n<=8) return n; } } return 0; }
+  // fps:N: the constant rate ffmpeg produces (default 30 in the hook).
+  function fpsOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^fps:(\d+)$/i.exec(w[i]); if(m) return +m[1]; } return 0; }
+  // rolloff:x/y/z/near/far/max/min: the hook attenuates the stream by the player's distance,
+  // fading from max at near to min at far. The server always sends all seven.
+  function rolloffOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^rolloff:(.+)$/i.exec(w[i]); if(m) return m[1].split('/').join(','); } return ''; }
+  // pan: also stereo-pan it by bearing (off by default).
+  function panOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ if(/^pan$/i.test(w[i])) return true; } return false; }
   function publish(){
-    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(stream?';src='+m:'');
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')+(stream?';src='+m:'');
     // The client forwards volume while the state is playing or paused, and only flushes a
     // pending comment-visibility toggle then too; it reads the word from .value here.
     var sf=$('statusForm'); if(sf) sf.value='value='+(state.paused?'paused':'playing')+' (statusForm)';

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -33,6 +33,8 @@ body.tv #comments{top:36px}
 .corner{position:absolute;width:12px;height:12px;background:#f80}
 .panel{position:absolute;outline:2px solid #f80}
 .panel .lab{position:absolute;left:4px;top:2px;font-size:11px;color:#f80}
+.card{position:absolute;background:#0d0b1a;color:#e8e6f0;text-align:center;font-family:Verdana,Arial,sans-serif;font-weight:bold;overflow:hidden}
+.card .w{position:absolute;left:0;width:100%;letter-spacing:4px}
 </style></head><body>
 <div id="navi"></div>
 <div id="flvplayer_container">
@@ -43,6 +45,8 @@ body.tv #comments{top:36px}
     <div id="calls">calls from the client appear here</div>
   </div>
 </div>
+<!-- A page source (http/https) is shown in the frame; stream sources go to the hook. -->
+<iframe id="frame" style="position:absolute;left:0;top:0;width:0;height:0;border:0;display:none" frameborder="0" scrolling="no"></iframe>
 <div id="external_nico_0"></div>
 <!-- The client reads this element's .value for "value=<state> " (space-terminated) to learn the
      player state, and gates ext_setCommentVisible's local flush on it reading playing or paused.
@@ -86,12 +90,114 @@ body.tv #comments{top:36px}
   function note(s){
     log.unshift(s); if(log.length>6) log.length=6; calls.innerHTML=log.join('<br>');
   }
-  // The launcher hook reads volume and mute from the title, which must survive every update.
+  // The launcher hook reads volume, mute and the source to play from the title; the server put
+  // the source there when this page was served, and it must survive every update.
+  var src=(function(){ var m=/;src=(.*)$/.exec(document.title||''); return m?m[1]:''; })();
+  // Whether this page needs to poll at all: not for a room TV, which the client re-navigates on
+  // every assignment change, nor for live-watch (the Stage), which /screen pushes a reload to
+  // instead. A town screen (a channel-screen, Akihabara confirmed) has neither guarantee, so it
+  // is the one case left polling.
+  var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
+  var frame=$('frame');
+  function isPage(v){ return /^https?:\/\//i.test(v); }
+  // The main source goes to the main panel: stream sources are published for the hook; pages
+  // are framed here.
+  function mainOf(v){ return (v||'').split(' ')[0]; }
+  // The main panel, in crop coordinates: a TV shows all of its crop, the Stage wall its main LED.
+  var panel=isLive?[7,65,543,382]:[0,0,486,343];
   function publish(){
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0);
+    var m=mainOf(src);
+    var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+(stream?';src='+m:'');
     // The client forwards volume while the state is playing or paused, and only flushes a
     // pending comment-visibility toggle then too; it reads the word from .value here.
     var sf=$('statusForm'); if(sf) sf.value='value='+(state.paused?'paused':'playing')+' (statusForm)';
+  }
+  // "title": a title card, "aisp-emu" centred in each panel on a dark background ('all'), or
+  // on the Stage banner alone ('top') while the main panel plays something.
+  var cards=[];
+  function showTitleCard(mode){
+    for(var i=0;i<cards.length;i++) box.removeChild(cards[i]);
+    cards=[];
+    if(!mode) return;
+    var rects=isLive?(mode==='top'?[[7,7,543,53,26]]:[[7,7,543,53,26],[7,65,543,382,56]]):(mode==='top'?[]:[[0,0,486,343,48]]);
+    for(var r=0;r<rects.length;r++){
+      var x=rects[r][0], y=rects[r][1], w=rects[r][2], h=rects[r][3], fs=rects[r][4];
+      var c=document.createElement('div'); c.className='card';
+      c.style.left=x+'px'; c.style.top=y+'px'; c.style.width=w+'px'; c.style.height=h+'px';
+      var t=document.createElement('div'); t.className='w'; t.style.fontSize=fs+'px'; t.style.lineHeight=fs+'px'; t.style.top=Math.round((h-fs)/2)+'px'; t.innerHTML='aisp-emu';
+      c.appendChild(t);
+      box.appendChild(c); cards.push(c);
+    }
+  }
+  // While a real source is up, the page is a blank black base under it.
+  function showDiagnostics(on){
+    var ids=['title','meta','calls','pulse','statusForm'];
+    for(var i=0;i<ids.length;i++){ var e=$(ids[i]); if(e) e.style.visibility=on?'visible':'hidden'; }
+    var leds=[$('led-top'),$('led-main')];
+    for(var k=0;k<leds.length;k++) leds[k].style.background=on?'#1a1a2e':'#000';
+    var cs=document.getElementsByTagName('div');
+    for(var j=0;j<cs.length;j++) if(cs[j].className==='corner'||cs[j].className==='panel') cs[j].style.visibility=on?'visible':'hidden';
+  }
+  // Calibration: a fine grid over the whole crop (lines every 10 px, labels every 50) so a
+  // panel's edges can be read in game. Drawn as page-coordinate lines over everything.
+  var grid=null;
+  function showGrid(on){
+    if(grid){ box.removeChild(grid); grid=null; }
+    if(!on) return;
+    grid=document.createElement('div'); grid.style.position='absolute'; grid.style.left='0'; grid.style.top='0';
+    var W=isLive?950:486, H=isLive?520:343;
+    grid.style.width=W+'px'; grid.style.height=H+'px'; grid.style.background='#fff';
+    for(var y=0;y<=H;y+=10){ var l=document.createElement('div'); l.style.position='absolute'; l.style.left='0'; l.style.top=y+'px'; l.style.width=W+'px'; l.style.height='1px'; l.style.background=(y%50)?'#cde':'#06c'; grid.appendChild(l); }
+    for(var x=0;x<=W;x+=10){ var v=document.createElement('div'); v.style.position='absolute'; v.style.left=x+'px'; v.style.top='0'; v.style.width='1px'; v.style.height=H+'px'; v.style.background=(x%50)?'#cde':'#06c'; grid.appendChild(v); }
+    for(var y2=0;y2<H;y2+=50) for(var x2=0;x2<W;x2+=50){
+      var t=document.createElement('div'); t.style.position='absolute'; t.style.left=(x2+2)+'px'; t.style.top=(y2+1)+'px';
+      t.style.fontSize='9px'; t.style.color='#000'; t.style.lineHeight='9px'; t.innerHTML=x2+'/'+y2; grid.appendChild(t);
+    }
+    box.appendChild(grid);
+  }
+  // c:x1/y1:x2/y2:x3/y3:x4/y4 ... : rectangles by opposite corners, drawn with their numbers so
+  // they can be adjusted from chat until they sit on the panel edges (slashes: the client
+  // splits chat arguments on commas).
+  var rectsLayer=null;
+  function showRects(spec){
+    if(rectsLayer){ box.removeChild(rectsLayer); rectsLayer=null; }
+    if(!spec) return;
+    rectsLayer=document.createElement('div'); rectsLayer.style.position='absolute'; rectsLayer.style.left='0'; rectsLayer.style.top='0';
+    var pts=spec.split(':'), colors=['#f80','#0f0','#f0f','#0ff'];
+    for(var i=0;i+1<pts.length;i+=2){
+      var a=pts[i].split('/'), b=pts[i+1].split('/');
+      var x1=Math.min(+a[0],+b[0]), y1=Math.min(+a[1],+b[1]), x2=Math.max(+a[0],+b[0]), y2=Math.max(+a[1],+b[1]);
+      if(isNaN(x1)||isNaN(y1)||isNaN(x2)||isNaN(y2)) continue;
+      var r=document.createElement('div'); r.style.position='absolute'; r.style.left=x1+'px'; r.style.top=y1+'px';
+      r.style.width=(x2-x1)+'px'; r.style.height=(y2-y1)+'px'; r.style.border='2px solid '+colors[(i/2)%colors.length];
+      r.style.boxSizing='border-box';
+      var t=document.createElement('div'); t.style.position='absolute'; t.style.left='6px'; t.style.top='4px'; t.style.fontSize='12px'; t.style.color=colors[(i/2)%colors.length];
+      t.innerHTML=x1+','+y1+' - '+x2+','+y2; r.appendChild(t);
+      rectsLayer.appendChild(r);
+    }
+    box.appendChild(rectsLayer);
+  }
+  function place(f,x,y,w,h,url){
+    f.style.left=x+'px'; f.style.top=y+'px'; f.style.width=w+'px'; f.style.height=h+'px'; f.style.display='block';
+    if(f.src!==url) f.src=url;
+  }
+  function hide(f){ f.style.display='none'; if(f.src) f.src='about:blank'; }
+  function applySource(){
+    var m=mainOf(src);
+    var ox=isLive?0:9, oy=isLive?0:15; // the crop inside the page
+    showGrid(m==='calibrate');
+    showRects(/^c:/i.test(m)?m.substring(2):null);
+    var diagnostic = !m || m==='calibrate' || /^c:/i.test(m);
+    showDiagnostics(diagnostic);
+    // A banner left free by a playing main panel shows the title card rather than nothing.
+    var topFree=isLive && m && m!=='title' && m!=='blank' && !diagnostic;
+    showTitleCard(m==='title'?'all':(topFree?'top':null));
+    if(isPage(m))
+      place(frame, ox+panel[0], oy+panel[1], panel[2], panel[3], m); // a page as the source: over the main panel
+    else
+      hide(frame);
+    publish();
   }
   function updateComments(){
     var el=$('comments'); if(!el) return;
@@ -121,10 +227,32 @@ body.tv #comments{top:36px}
   ext.ext_isRepeat=function(r){ note('ext_isRepeat -> '+r); return ret(r, state.repeat?1:0); };
   ext.ext_getPlayheadTime=function(r){ note('ext_getPlayheadTime -> '+r); return ret(r, Math.floor((new Date().getTime()-t0)/1000)); };
   ext.ext_getTotalTime=function(r){ note('ext_getTotalTime -> '+r); return ret(r, state.total); };
-  publish();
+  applySource();
+  // The server may change what a screen plays after it loaded, with nothing client-side to tell
+  // it, so it keeps asking and republishes the title, which the hook follows, unless noPoll
+  // (above) says the server already pushes this page a reload instead: a room TV re-navigates on
+  // every assignment change on its own (movie set, channel switch, room re-entry), and live-watch
+  // (the Stage) gets notify_nicolive_reload from /screen. A /channel-screen (a town map's own
+  // screen, Akihabara confirmed) has neither guarantee, so it is the one case polling; the
+  // pushed cases never run this at all, so a relaxed 30s interval here only affects that one
+  // less time-sensitive case.
+  function pollSource(){
+    try{
+      var xhr=new XMLHttpRequest();
+      xhr.open('GET','screen-source?route='+encodeURIComponent(path)+'&'+(window.location.search||'?').substring(1)+'&_='+new Date().getTime(),true);
+      xhr.onreadystatechange=function(){
+        if(xhr.readyState!==4||xhr.status!==200) return;
+        var m=/"src"\s*:\s*"((?:[^"\\]|\\.)*)"/.exec(xhr.responseText||'');
+        var next=m?m[1].replace(/\\"/g,'"').replace(/\\\\/g,'\\'):'';
+        if(next!==src){ src=next; applySource(); }
+      };
+      xhr.send(null);
+    }catch(e){}
+  }
+  if(!noPoll) setInterval(pollSource,30000);
   setInterval(function(){
     var s=Math.floor((new Date().getTime()-t0)/1000);
-    meta.innerHTML=kind+' ('+path+')<br>'+(params.length?params.join(' &nbsp; '):'no parameters')+'<br>mode: '+mode+' &nbsp; clock: '+s+'s &nbsp; volume: '+state.volume+(state.mute?' (muted)':'');
+    meta.innerHTML=kind+' ('+path+')<br>'+(params.length?params.join(' &nbsp; '):'no parameters')+'<br>mode: '+mode+' &nbsp; clock: '+s+'s &nbsp; volume: '+state.volume+(state.mute?' (muted)':'')+'<br>source: '+(src||'(none, showing this page)');
     pulse.style.background=(s%2)?'#f80':'#0cf';
   },250);
 })();

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -25,9 +25,16 @@ body.tv #title{font-size:18px;top:6px}
 body.tv #meta{top:32px}
 #calls{position:absolute;left:12px;bottom:8px;width:90%;height:90px;font-size:12px;color:#fc9;overflow:hidden}
 #pulse{position:absolute;right:12px;top:10px;width:24px;height:24px;background:#f80}
-/* Dummy feedback for ext_setCommentVisible: no real comment data, just a small on/off indicator. */
+/* Dummy feedback for ext_setCommentVisible: no real comment data; the toggle switches the
+   comment overlay (see .c below) on and off, and this small on/off indicator with it. */
 #comments{position:absolute;right:12px;top:40px;font-size:12px;color:#8f8}
 body.tv #comments{top:36px}
+/* The comment overlay itself: MS Gothic at 16 px is a bitmap strike, no smoothing, so the
+   outline trick keeps hard edges under colour keying. Each comment is the text drawn 8 times
+   in black around it, one in colour on top. */
+.c{position:absolute;white-space:nowrap;font:bold 28px/32px "MS Gothic","ＭＳ ゴシック",monospace;height:32px}
+.c span{position:absolute;left:0;top:0;color:#000}
+.c span.f{color:#fff}
 #outside{position:absolute;left:9px;top:600px;font-size:12px;color:#888}
 .ret{position:absolute;left:520px;font-size:12px;color:#00f}
 .corner{position:absolute;width:12px;height:12px;background:#f80}
@@ -44,6 +51,11 @@ body.tv #comments{top:36px}
     <div id="comments">💬 on</div>
     <div id="calls">calls from the client appear here</div>
   </div>
+  <!-- Dummy feedback for ext_setCommentVisible: not real comments, just the movie id flying
+       across the video box Nico style, key-composited so it survives the hook's own video fill.
+       A child of flvplayer_container, like the key fill it sits over, so its coordinates are
+       already crop-space with no ox/oy translation needed. -->
+  <div id="commentLayer" style="position:absolute;left:0;top:0;width:0;height:0;overflow:hidden;display:none"></div>
 </div>
 <!-- A page source (http/https) or a main: frame page is shown in the first frame, a banner: page
      in the second; stream sources go to the hook. -->
@@ -95,10 +107,16 @@ body.tv #comments{top:36px}
   // The launcher hook reads volume, mute and the source to play from the title; the server put
   // the source there when this page was served, and it must survive every update.
   var src=(function(){ var m=/;src=(.*)$/.exec(document.title||''); return m?m[1]:''; })();
-  // Whether this page needs to poll at all: not for a room TV, which the client re-navigates on
-  // every assignment change, nor for live-watch (the Stage), which /screen and /channel both push
-  // a reload to instead. A town screen (a channel-screen that did not resolve to a room TV,
-  // Akihabara confirmed) has neither guarantee, so it is the one case left polling.
+  // A genuine room TV: the server already knows this from resolving map/tvid against the
+  // database, which the page cannot do from the URL alone (a /channel-screen is a room TV only
+  // on a MyRoom map; on a town map, Akihabara confirmed, it is a real screen with no such thing).
+  // Also gates the comment overlay below, so it can never show on anything but a room TV, no
+  // matter what ext_setCommentVisible is called with.
+  var roomTv=/;roomtv=1(?:;|$)/.test(document.title||'');
+  // Separately, whether this page needs to poll at all: true for a room TV (above), and also for
+  // live-watch (the Stage), which /screen and /channel both push a reload to instead. A town
+  // screen (a channel-screen that did not resolve to a room TV, Akihabara confirmed) has neither
+  // guarantee, so it is the one case still left polling.
   var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
   var frame=$('frame'), bannerFrame=$('banner');
   function isPage(v){ return /^https?:\/\//i.test(v); }
@@ -138,6 +156,9 @@ body.tv #comments{top:36px}
     for(var i=1;i<w.length;i++){ if(/^key$/i.test(w[i])) return '100010'; var m=/^key:([0-9a-f]{6})$/i.exec(w[i]); if(m) return m[1].toLowerCase(); }
     return '';
   }
+  // The source's own key wins if it has one; otherwise the comment overlay forces the bare
+  // DirectDraw key on so its text (drawn outside the key colour) survives the hook's video fill.
+  function effectiveKey(v){ return keyOf(v) || (roomTv && state.comment ? '100010' : ''); }
   // crop:sw/sh:cx/cy: the hook renders the picture at sw x sh and paints the box-sized window
   // starting at cx,cy of it (zoom in, or cut a region out). For electron: sw/sh is the browser's
   // layout viewport. Published as crop=sw,sh,cx,cy.
@@ -171,7 +192,7 @@ body.tv #comments{top:36px}
     return t;
   }
   function publish(){
-    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=effectiveKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
     document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
       +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');
@@ -274,12 +295,15 @@ body.tv #comments{top:36px}
   }
   function hide(f){ f.style.display='none'; if(f.src) f.src='about:blank'; }
   function applySource(){
-    var m=mainOf(src), mp=mainPageOf(src), bn=bannerOf(src), raw=rawPageOf(src), g=geometry(src), vb=g.crop, k=keyOf(src);
+    var m=mainOf(src), mp=mainPageOf(src), bn=bannerOf(src), raw=rawPageOf(src), g=geometry(src), vb=g.crop, k=effectiveKey(src);
     var ox=isLive?0:9, oy=isLive?0:15, cw=isLive?950:486, ch=isLive?520:343; // the crop inside the page
     var rawFrame=raw&&!isPage(m)&&(hasBox(src)||!!k), rawBanner=raw&&!rawFrame;
     // The built-in gold frame and key fill are only for a box without a frame page: a frame
-    // page paints around (and, keyed, over) the video itself.
-    showBoxFrame(m&&!isPage(m)&&m!=='blank'&&!mp&&!rawFrame?vb:null, k);
+    // page paints around (and, keyed, over) the video itself. The comment overlay is the same
+    // box again, on top, while comments are on.
+    var videoBox=m&&!isPage(m)&&m!=='blank'&&!mp&&!rawFrame?vb:null;
+    showBoxFrame(videoBox, k);
+    updateCommentLayer(videoBox&&roomTv&&state.comment?vb:null);
     showGrid(m==='calibrate');
     showRects(/^c:/i.test(m)?m.substring(2):null);
     var diagnostic = !m || m==='calibrate' || /^c:/i.test(m);
@@ -303,6 +327,65 @@ body.tv #comments{top:36px}
       hide(bannerFrame);
     publish();
   }
+  // The movie id flying across the box in the comment overlay: the raw, still n:-tagged
+  // movieid= this page was navigated with when there is one (a room TV), else the resolved
+  // src's own main token; the n: tag is the server's own wire budget, never meant to be read.
+  function commentText(){
+    var mid=(q.movieid||mainOf(src)||'aisp-emu').replace(/\s*\bn:\d+\b/gi,'').trim();
+    return mid||'aisp-emu';
+  }
+  // One flying comment: the text drawn 8 times in black, offset a pixel in every direction,
+  // with one more in colour on top, so it stays legible over anything without anti-aliasing.
+  function makeComment(text,color){
+    var d=document.createElement('div'); d.className='c';
+    var offs=[[-1,-1],[0,-1],[1,-1],[-1,0],[1,0],[-1,1],[0,1],[1,1],[0,0]];
+    for(var i=0;i<offs.length;i++){
+      var s=document.createElement('span');
+      if(i===8){ s.className='f'; s.style.color=color; }
+      s.style.left=offs[i][0]+'px'; s.style.top=offs[i][1]+'px';
+      s.appendChild(document.createTextNode(text));
+      d.appendChild(s);
+    }
+    $('commentLayer').appendChild(d);
+    return d;
+  }
+  // Only one comment on screen at a time: the next one spawns as soon as the previous one's
+  // tail has cleared the edge, never before. A shorter tick than the animation actually needs
+  // (25/s) is what makes it look smooth rather than stepping visibly frame to frame.
+  var commentTickMs=40, commentCrossMs=9000;
+  var comment=null, commentTimer=null;
+  function spawnComment(){
+    var cl=$('commentLayer'), bw=cl.clientWidth, bh=cl.clientHeight;
+    if(bw<=0||bh<=0) return;
+    var d=makeComment(commentText(),'#fff'), w=d.offsetWidth||220;
+    var speed=(bw+w)/(commentCrossMs/commentTickMs);
+    d.style.top='8px'; d.style.left=bw+'px';
+    comment={el:d,x:bw,speed:speed,w:w};
+  }
+  function commentStep(){
+    if(!comment){ spawnComment(); return; }
+    var cl=$('commentLayer'), c=comment;
+    c.x-=c.speed; c.el.style.left=Math.round(c.x)+'px';
+    if(c.x+c.w<0){ cl.removeChild(c.el); comment=null; }
+  }
+  // Sized and positioned to the video box (crop-space, like the key fill it sits over) while
+  // comments are on; torn down and hidden otherwise.
+  function updateCommentLayer(vb){
+    var cl=$('commentLayer');
+    if(!vb){
+      if(commentTimer){ clearInterval(commentTimer); commentTimer=null; }
+      if(comment){ cl.removeChild(comment.el); comment=null; }
+      cl.style.display='none';
+      return;
+    }
+    cl.style.left=vb[0]+'px'; cl.style.top=vb[1]+'px'; cl.style.width=vb[2]+'px'; cl.style.height=vb[3]+'px';
+    cl.style.display='block';
+    // showBoxFrame just above appended a fresh key fill after this div in the DOM, which would
+    // otherwise paint over it (later siblings stack on top with no z-index set anywhere here);
+    // move it back to the end so the comments stay above the key colour, not hidden under it.
+    box.appendChild(cl);
+    if(!commentTimer) commentTimer=setInterval(commentStep,commentTickMs);
+  }
   function updateComments(){
     var el=$('comments'); if(!el) return;
     el.textContent=state.comment?'💬 on':'💬 off';
@@ -325,7 +408,7 @@ body.tv #comments{top:36px}
   ext.ext_setMute=function(m){ note('ext_setMute '+m); state.mute=!!m; publish(); };
   ext.ext_setPlayheadTime=function(t){ note('ext_setPlayheadTime '+t); state.playhead=Number(t)||0; };
   ext.ext_setVolume=function(n){ note('ext_setVolume '+n); state.volume=Math.max(0,Math.min(100,Math.round(Number(n)))); publish(); };
-  ext.ext_setCommentVisible=function(b){ note('ext_setCommentVisible '+b); state.comment=!!b; updateComments(); };
+  ext.ext_setCommentVisible=function(b){ note('ext_setCommentVisible '+b); state.comment=!!b; updateComments(); applySource(); };
   ext.ext_setRepeat=function(b){ note('ext_setRepeat '+b); state.repeat=!!b; };
   ext.ext_isMute=function(r){ note('ext_isMute -> '+r); return ret(r, state.mute?1:0); };
   ext.ext_getVolume=function(r){ note('ext_getVolume -> '+r); return ret(r, state.volume); };

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -26,7 +26,9 @@ body.tv #meta{top:32px}
 #calls{position:absolute;left:12px;bottom:8px;width:90%;height:90px;font-size:12px;color:#fc9;overflow:hidden}
 #pulse{position:absolute;right:12px;top:10px;width:24px;height:24px;background:#f80}
 /* Dummy feedback for ext_setCommentVisible: no real comment data; the toggle switches the
-   comment overlay (see .c below) on and off, and this small on/off indicator with it. */
+   comment overlay (see .c below) on and off. This small on/off indicator is diagnostics only:
+   it sits inside the TV's crop and a keyed room TV lets it through over the video, so it is
+   hidden with the other diagnostics whenever a real source plays. */
 #comments{position:absolute;right:12px;top:40px;font-size:12px;color:#8f8}
 body.tv #comments{top:36px}
 /* The comment overlay itself: MS Gothic at 16 px is a bitmap strike, no smoothing, so the
@@ -102,7 +104,7 @@ body.tv #comments{top:36px}
   var params=[]; for(var k in q) if(q.hasOwnProperty(k)) params.push(k+'='+q[k]);
   var meta=$('meta'), calls=$('calls'), ext=$('external_nico_0'), pulse=$('pulse');
   var mode=document.documentMode||'none', t0=new Date().getTime(), log=[];
-  var state={ volume:100, mute:false, repeat:true, comment:true, playhead:0, total:0, paused:false };
+  var state={ volume:100, mute:false, repeat:true, comment:false, playhead:0, total:0, paused:false };
   function note(s){
     log.unshift(s); if(log.length>6) log.length=6; calls.innerHTML=log.join('<br>');
   }
@@ -120,6 +122,11 @@ body.tv #comments{top:36px}
   // screen (a channel-screen that did not resolve to a room TV, Akihabara confirmed) has neither
   // guarantee, so it is the one case still left polling.
   var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
+  // The comment overlay starts from the server's default for this TV (comment=1 in the title,
+  // otherwise off). The client never sets it on its own: its panel button is an empty case in
+  // the binary, and only the server's set-comment-visible notify (or the launcher hook filling
+  // that case in) reaches ext_setCommentVisible. It starts over on every re-navigation.
+  state.comment=/;comment=1(?:;|$)/.test(document.title||'');
   var frame=$('frame'), bannerFrame=$('banner');
   function isPage(v){ return /^https?:\/\//i.test(v); }
   // "<main> [main:<url>] [banner:<url>] [<url>] [box:x/y/w/h] ...": the main source goes to the
@@ -160,7 +167,12 @@ body.tv #comments{top:36px}
   }
   // The source's own key wins if it has one; otherwise the comment overlay forces the bare
   // DirectDraw key on so its text (drawn outside the key colour) survives the hook's video fill.
-  function effectiveKey(v){ return keyOf(v) || (roomTv && state.comment ? '100010' : ''); }
+  // A room TV is keyed whether or not comments are shown: the hook composites the page over the
+  // video by key colour, and switching it between keyed and plain on a toggle races the page's
+  // repaint, which shows one frame of the page's black base and indicator before the video
+  // returns. Keying a TV-sized box every frame costs nothing noticeable, so the toggle only
+  // hides the comment layer.
+  function effectiveKey(v){ return keyOf(v) || (roomTv ? '100010' : ''); }
   // crop:sw/sh:cx/cy: the hook renders the picture at sw x sh and paints the box-sized window
   // starting at cx,cy of it (zoom in, or cut a region out). For electron: sw/sh is the browser's
   // layout viewport. Published as crop=sw,sh,cx,cy.
@@ -241,7 +253,7 @@ body.tv #comments{top:36px}
   }
   // While a real source is up, the page is a blank black base under it.
   function showDiagnostics(on){
-    var ids=['title','meta','calls','pulse','statusForm'];
+    var ids=['title','meta','calls','pulse','statusForm','comments'];
     for(var i=0;i<ids.length;i++){ var e=$(ids[i]); if(e) e.style.visibility=on?'visible':'hidden'; }
     var leds=[$('led-top'),$('led-main')];
     for(var k=0;k<leds.length;k++) leds[k].style.background=on?'#1a1a2e':'#000';

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -316,7 +316,9 @@ body.tv #comments{top:36px}
     d.innerText=String(value); d.value=String(value); document.body.appendChild(d); return value;
   }
   // The client's play/pause toggle is a single ext_play(bool), called with whether it is now
-  // playing (false for pause); there is no separate ext_pause in real use.
+  // playing (false for pause); there is no separate ext_pause in real use. This holds this
+  // screen only; the shared timeline (what pause/resume actually moves for everyone in the
+  // room) is driven over the network by NicotvPlayRequest, not by this call.
   ext.ext_play=function(playing){ note('ext_play('+playing+')'); state.paused=!playing; publish(); };
   ext.ext_pause=function(){ note('ext_pause'); state.paused=true; publish(); };
   ext.ext_stop=function(){ note('ext_stop'); state.paused=true; publish(); };

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -168,13 +168,15 @@ body.tv #comments{top:36px}
   // scrollx:N, scrolly:N, or scroll:x/y: document offset the off-screen browser (electron:) enforces.
   // Null when no scroll extra is present (the hook then shows scrollbars again).
   function scrollOf(v){
-    var x=0,y=0,set=false,w=(v||'').split(' ');
+    // "given", not "set": Wine's jscript (the engine behind its IE, used for testing this page
+    // in the local prefix) refuses "set" as a variable name, although IE itself accepts it.
+    var x=0,y=0,given=false,w=(v||'').split(' ');
     for(var i=1;i<w.length;i++){
-      var mx=/^scrollx:(-?\d+)$/i.exec(w[i]); if(mx){ x=+mx[1]; set=true; }
-      var my=/^scrolly:(-?\d+)$/i.exec(w[i]); if(my){ y=+my[1]; set=true; }
-      var m=/^scroll:(-?\d+)\/(-?\d+)$/i.exec(w[i]); if(m){ x=+m[1]; y=+m[2]; set=true; }
+      var mx=/^scrollx:(-?\d+)$/i.exec(w[i]); if(mx){ x=+mx[1]; given=true; }
+      var my=/^scrolly:(-?\d+)$/i.exec(w[i]); if(my){ y=+my[1]; given=true; }
+      var m=/^scroll:(-?\d+)\/(-?\d+)$/i.exec(w[i]); if(m){ x=+m[1]; y=+m[2]; given=true; }
     }
-    return set?[x,y]:null;
+    return given?[x,y]:null;
   }
   // scale:N: Chromium zoom for electron: (1 = 100%). Not a texture stretch.
   function scaleOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^scale:([0-9]*\.?[0-9]+)$/i.exec(w[i]); if(m){ var n=+m[1]; if(n>=0.1&&n<=8) return n; } } return 0; }

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -96,9 +96,9 @@ body.tv #comments{top:36px}
   // the source there when this page was served, and it must survive every update.
   var src=(function(){ var m=/;src=(.*)$/.exec(document.title||''); return m?m[1]:''; })();
   // Whether this page needs to poll at all: not for a room TV, which the client re-navigates on
-  // every assignment change, nor for live-watch (the Stage), which /screen pushes a reload to
-  // instead. A town screen (a channel-screen, Akihabara confirmed) has neither guarantee, so it
-  // is the one case left polling.
+  // every assignment change, nor for live-watch (the Stage), which /screen and /channel both push
+  // a reload to instead. A town screen (a channel-screen that did not resolve to a room TV,
+  // Akihabara confirmed) has neither guarantee, so it is the one case left polling.
   var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
   var frame=$('frame'), bannerFrame=$('banner');
   function isPage(v){ return /^https?:\/\//i.test(v); }
@@ -338,10 +338,10 @@ body.tv #comments{top:36px}
   // it, so it keeps asking and republishes the title, which the hook follows, unless noPoll
   // (above) says the server already pushes this page a reload instead: a room TV re-navigates on
   // every assignment change on its own (movie set, channel switch, room re-entry), and live-watch
-  // (the Stage) gets notify_nicolive_reload from /screen. A /channel-screen (a town map's own
-  // screen, Akihabara confirmed) has neither guarantee, so it is the one case polling; the
-  // pushed cases never run this at all, so a relaxed 30s interval here only affects that one
-  // less time-sensitive case.
+  // (the Stage) gets notify_nicolive_reload from both /screen and /channel. A /channel-screen
+  // that is not a room TV (a town map's own screen, Akihabara confirmed) has neither guarantee,
+  // so it is the one case polling; the pushed cases never run this at all, so a relaxed 30s
+  // interval here only affects that one less time-sensitive case.
   function pollSource(){
     try{
       var xhr=new XMLHttpRequest();

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -162,13 +162,22 @@ body.tv #comments{top:36px}
   function rolloffOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^rolloff:(.+)$/i.exec(w[i]); if(m) return m[1].split('/').join(','); } return ''; }
   // pan: also stereo-pan it by bearing (off by default).
   function panOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ if(/^pan$/i.test(w[i])) return true; } return false; }
+  // start:<unix> offset:<seconds> [paused:<unix>]: a video's shared timeline (at start it was at
+  // offset and playing; paused since paused). The hook seeks to the position, which stops
+  // advancing at the pause time, and holds while paused; hold=1 is this screen's own pause.
+  function timelineOf(v){
+    var w=(v||'').split(' '), t={start:0,offset:0,paused:0};
+    for(var i=1;i<w.length;i++){ var m=/^(start|offset|paused):([0-9.]+)$/i.exec(w[i]); if(m) t[m[1].toLowerCase()]=+m[2]; }
+    return t;
+  }
   function publish(){
-    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=keyOf(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')+(stream?';src='+m:'');
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
+      +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');
     // The client forwards volume while the state is playing or paused, and only flushes a
     // pending comment-visibility toggle then too; it reads the word from .value here.
-    var sf=$('statusForm'); if(sf) sf.value='value='+(state.paused?'paused':'playing')+' (statusForm)';
+    var sf=$('statusForm'); if(sf) sf.value='value='+(tl.paused||state.paused?'paused':'playing')+' (statusForm)';
   }
   // "title": a title card, "aisp-emu" centred in each panel on a dark background ('all'), or
   // on the Stage banner alone ('top') while the main panel plays something and nothing else

--- a/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
+++ b/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
@@ -68,7 +68,9 @@ public sealed class AreaNicotvHandlersTests
                 nicotvId = reader.ReadUInt();
                 Assert.NotEqual(0u, nicotvId);
                 var initial = NicotvData.FromBytes(response.Payload.AsSpan(sizeof(uint) * 2));
-                Assert.Equal("", initial.MovieId);
+                // An empty movie id still carries n: alone, so the screen page's movieid=
+                // round-trips the furniture id even for a TV that has never been set.
+                Assert.Equal($"n:{nicotvId}", initial.MovieId);
                 Assert.Equal(NicotvPlaybackState.Closed, initial.PlaybackState);
 
                 session.Sent.Clear();
@@ -96,7 +98,7 @@ public sealed class AreaNicotvHandlersTests
                 Assert.Equal(2u, reader.ReadUInt());
                 Assert.Equal(nicotvId, reader.ReadUInt());
                 var opened = NicotvData.FromBytes(response.Payload.AsSpan(sizeof(uint) * 2));
-                Assert.Equal("Hello World", opened.MovieId);
+                Assert.Equal($"Hello World n:{nicotvId}", opened.MovieId);
                 Assert.Equal(NicotvPlaybackState.Playing, opened.PlaybackState);
             }
 
@@ -118,7 +120,7 @@ public sealed class AreaNicotvHandlersTests
                 Assert.Equal(2u, reader.ReadUInt());
                 Assert.Equal(nicotvId, reader.ReadUInt());
                 Assert.Equal(
-                    "Hello World",
+                    $"Hello World n:{nicotvId}",
                     NicotvData.FromBytes(response.Payload.AsSpan(sizeof(uint) * 2)).MovieId
                 );
             }
@@ -410,7 +412,8 @@ public sealed class AreaNicotvHandlersTests
             state.RegisterClient(ServerType.Area, actor);
             state.RegisterClient(ServerType.Area, peer);
 
-            var playHandler = new AreaNicotvPlayHandler(repository, state);
+            var screenAssignments = new ScreenAssignments();
+            var playHandler = new AreaNicotvPlayHandler(repository, state, screenAssignments);
             await ((IPacketHandler)playHandler).HandleAsync(
                 BuildUIntPayload(nicotvId, (uint)NicotvPlaybackState.Paused),
                 actor,
@@ -433,7 +436,7 @@ public sealed class AreaNicotvHandlersTests
 
             actor.Sent.Clear();
             peer.Sent.Clear();
-            var movieHandler = new AreaNicotvSetMovieHandler(repository, state);
+            var movieHandler = new AreaNicotvSetMovieHandler(repository, state, screenAssignments);
             await ((IPacketHandler)movieHandler).HandleAsync(
                 BuildSetMoviePayload(nicotvId, "sm9"),
                 actor,
@@ -448,6 +451,40 @@ public sealed class AreaNicotvHandlersTests
             );
             Assert.Equal(PacketType.NotifyNicotvSetMovie, Assert.Single(peer.Sent).Type);
             Assert.Equal("sm9", nicotv.MovieId);
+
+            // Setting the movie also starts that room's shared timeline for it at zero. The
+            // screen page round-trips the n: tag the handler appended, so that is how a
+            // real poll would ask for this TV; a plain "sm9" (no n: tag) is a different TV.
+            var taggedMovieId = $"sm9 n:{nicotvId}";
+            Assert.Contains(
+                "offset:0",
+                screenAssignments.Resolve("room-tv", taggedMovieId, actor.MapId, actor.ChannelId)
+            );
+
+            // The pause button (NicotvPlayRequest) pauses that TV's timeline for the room...
+            await ((IPacketHandler)playHandler).HandleAsync(
+                BuildUIntPayload(nicotvId, (uint)NicotvPlaybackState.Paused),
+                actor,
+                ct
+            );
+            Assert.Contains(
+                "paused:",
+                screenAssignments.Resolve("room-tv", taggedMovieId, actor.MapId, actor.ChannelId)
+            );
+            // ...but not some other TV's timeline (a different n: tag, or none at all).
+            Assert.DoesNotContain(
+                "paused:",
+                screenAssignments.Resolve(
+                    "room-tv",
+                    $"sm9 n:{nicotvId + 1}",
+                    actor.MapId,
+                    actor.ChannelId
+                )
+            );
+            Assert.DoesNotContain(
+                "paused:",
+                screenAssignments.Resolve("room-tv", "sm9", actor.MapId, actor.ChannelId)
+            );
         }
         finally
         {

--- a/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
+++ b/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
@@ -130,6 +130,81 @@ public sealed class AreaNicotvHandlersTests
     }
 
     [Fact]
+    public async Task OpenByFurniture_NotifiesActorAndPeerWhenCommentVisibilityChanges()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+        try
+        {
+            var ct = TestContext.Current.CancellationToken;
+            await SeedNicotvFurnitureAsync(options, ct);
+
+            await using var db = new MainContext(options);
+            var repository = new NicotvRepository(db);
+
+            var state = new SharedState();
+            var actor = CreateVisitorSession(2);
+            var peer = CreateVisitorSession(3);
+            state.RegisterClient(ServerType.Area, actor);
+            state.RegisterClient(ServerType.Area, peer);
+
+            var openHandler = new AreaNicotvOpenByFurnitureHandler(repository, state);
+            await ((IPacketHandler)openHandler).HandleAsync(
+                BuildOpenPayload(
+                    2,
+                    new NicotvData(commentVisibility: NicotvCommentVisibility.Visible)
+                ),
+                actor,
+                ct
+            );
+            var nicotvId = checked(
+                (uint)
+                    Assert
+                        .IsType<Nicotv>(await repository.GetOrCreateForFurnitureAsync(42, 2, ct))
+                        .Id
+            );
+            actor.Sent.Clear();
+            peer.Sent.Clear();
+
+            // Comment visibility has no dedicated set request of its own (confirmed against the
+            // client binary): the toggle button re-sends open-by-furniture with the new snapshot.
+            // recv_nicotv_set_comment_visible_r does not call the JS setter, only
+            // recv_notify_nicotv_set_comment_visible does, so the clicker needs that notify too,
+            // not just peers.
+            await ((IPacketHandler)openHandler).HandleAsync(
+                BuildOpenPayload(
+                    2,
+                    new NicotvData(commentVisibility: NicotvCommentVisibility.Hidden)
+                ),
+                actor,
+                ct
+            );
+
+            Assert.Equal(
+                [
+                    PacketType.NicotvSetCommentVisibleResponse,
+                    PacketType.NotifyNicotvSetCommentVisible,
+                    PacketType.NicotvOpenResponse,
+                ],
+                actor.Sent.Select(p => p.Type)
+            );
+            Assert.Equal(
+                BuildUIntPayload(nicotvId, (uint)NicotvCommentVisibility.Hidden),
+                actor.Sent[1].Payload
+            );
+            var peerNotify = Assert.Single(peer.Sent);
+            Assert.Equal(PacketType.NotifyNicotvSetCommentVisible, peerNotify.Type);
+            Assert.Equal(
+                BuildUIntPayload(nicotvId, (uint)NicotvCommentVisibility.Hidden),
+                peerNotify.Payload
+            );
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public async Task GetInfo_RejectsFurnitureOutsideTheCurrentRoom()
     {
         var (connection, options) = TestDb.CreateInMemoryMainContext();
@@ -218,9 +293,13 @@ public sealed class AreaNicotvHandlersTests
                 ct
             );
 
-            var response = Assert.Single(actor.Sent);
-            Assert.Equal(PacketType.NicotvSetChannelResponse, response.Type);
-            Assert.Equal(BuildUIntPayload(nicotvId, 1), response.Payload);
+            // The client's set_channel_r handler is a no-op, same as set_movie_r, so the sender
+            // needs the notify too, to load the channel on its own TV.
+            Assert.Equal(
+                [PacketType.NotifyNicotvSetChannel, PacketType.NicotvSetChannelResponse],
+                actor.Sent.Select(p => p.Type)
+            );
+            Assert.Equal(BuildUIntPayload(nicotvId, 1), actor.Sent[1].Payload);
             var notification = Assert.Single(peer.Sent);
             Assert.Equal(PacketType.NotifyNicotvSetChannel, notification.Type);
             Assert.Equal(BuildUIntPayload(nicotvId, 1), notification.Payload);
@@ -231,7 +310,7 @@ public sealed class AreaNicotvHandlersTests
             var closeHandler = new AreaNicotvCloseHandler(repository, state);
             await ((IPacketHandler)closeHandler).HandleAsync(BuildUIntPayload(nicotvId), actor, ct);
 
-            response = Assert.Single(actor.Sent);
+            var response = Assert.Single(actor.Sent);
             Assert.Equal(PacketType.NicotvCloseResponse, response.Type);
             Assert.Equal(BuildUIntPayload(0, nicotvId), response.Payload);
             notification = Assert.Single(peer.Sent);
@@ -338,9 +417,19 @@ public sealed class AreaNicotvHandlersTests
                 ct
             );
 
-            Assert.Equal(PacketType.NicotvPlayResponse, Assert.Single(actor.Sent).Type);
+            // The sender gets its own copy of the notify too, same as set_movie's notify (the
+            // client calls ext_play on receiving it, though testing showed that happens for
+            // either status, so it is not a play/pause toggle signal and Status goes out as-is).
+            Assert.Equal(
+                [PacketType.NotifyNicotvPlay, PacketType.NicotvPlayResponse],
+                actor.Sent.Select(p => p.Type)
+            );
             Assert.Equal(PacketType.NotifyNicotvPlay, Assert.Single(peer.Sent).Type);
             Assert.Equal(NicotvPlaybackState.Paused, nicotv.PlaybackState);
+
+            var notifyStatus = new PacketReader(actor.Sent[0].Payload);
+            notifyStatus.ReadUInt();
+            Assert.Equal((uint)NicotvPlaybackState.Paused, notifyStatus.ReadUInt());
 
             actor.Sent.Clear();
             peer.Sent.Clear();
@@ -351,7 +440,12 @@ public sealed class AreaNicotvHandlersTests
                 ct
             );
 
-            Assert.Equal(PacketType.NicotvSetMovieResponse, Assert.Single(actor.Sent).Type);
+            // The client's set_movie_r handler is a no-op, so the sender needs the notify as well
+            // to load the movie on its own TV.
+            Assert.Equal(
+                [PacketType.NotifyNicotvSetMovie, PacketType.NicotvSetMovieResponse],
+                actor.Sent.Select(p => p.Type)
+            );
             Assert.Equal(PacketType.NotifyNicotvSetMovie, Assert.Single(peer.Sent).Type);
             Assert.Equal("sm9", nicotv.MovieId);
         }

--- a/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
+++ b/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
@@ -109,6 +109,7 @@ public sealed class AreaNicotvHandlersTests
                 Assert.Equal(2u, stored.FurnitureId);
                 Assert.Equal("Hello World", stored.MovieId);
                 Assert.Equal(NicotvPlaybackState.Playing, stored.PlaybackState);
+                Assert.Equal(NicotvCommentVisibility.Hidden, stored.CommentVisibility);
 
                 var repository = new NicotvRepository(db);
                 var session = CreateVisitorSession();
@@ -132,7 +133,7 @@ public sealed class AreaNicotvHandlersTests
     }
 
     [Fact]
-    public async Task OpenByFurniture_NotifiesActorAndPeerWhenCommentVisibilityChanges()
+    public async Task OpenByFurniture_KeepsTheServersCommentVisibility()
     {
         var (connection, options) = TestDb.CreateInMemoryMainContext();
         try
@@ -149,6 +150,9 @@ public sealed class AreaNicotvHandlersTests
             state.RegisterClient(ServerType.Area, actor);
             state.RegisterClient(ServerType.Area, peer);
 
+            // The client's TV panel sends every open snapshot as comments visible, whatever the TV
+            // shows, and has no request for the field at all: it is the server's default for the
+            // TV (off), reaches the page through its title, and is never read back from a client.
             var openHandler = new AreaNicotvOpenByFurnitureHandler(repository, state);
             await ((IPacketHandler)openHandler).HandleAsync(
                 BuildOpenPayload(
@@ -158,47 +162,31 @@ public sealed class AreaNicotvHandlersTests
                 actor,
                 ct
             );
-            var nicotvId = checked(
-                (uint)
-                    Assert
-                        .IsType<Nicotv>(await repository.GetOrCreateForFurnitureAsync(42, 2, ct))
-                        .Id
+            var stored = Assert.IsType<Nicotv>(
+                await repository.GetOrCreateForFurnitureAsync(42, 2, ct)
+            );
+            Assert.Equal(NicotvCommentVisibility.Hidden, stored.CommentVisibility);
+            var opened = Assert.Single(actor.Sent, p => p.Type == PacketType.NicotvOpenResponse);
+            Assert.Equal(
+                NicotvCommentVisibility.Hidden,
+                NicotvData.FromBytes(opened.Payload.AsSpan(sizeof(uint) * 2)).CommentVisibility
             );
             actor.Sent.Clear();
             peer.Sent.Clear();
 
-            // Comment visibility has no dedicated set request of its own (confirmed against the
-            // client binary): the toggle button re-sends open-by-furniture with the new snapshot.
-            // recv_nicotv_set_comment_visible_r does not call the JS setter, only
-            // recv_notify_nicotv_set_comment_visible does, so the clicker needs that notify too,
-            // not just peers.
+            // A second open with the same snapshot changes nothing: no comment-visibility reply or
+            // notify goes out, to the clicker or to peers.
             await ((IPacketHandler)openHandler).HandleAsync(
                 BuildOpenPayload(
                     2,
-                    new NicotvData(commentVisibility: NicotvCommentVisibility.Hidden)
+                    new NicotvData(commentVisibility: NicotvCommentVisibility.Visible)
                 ),
                 actor,
                 ct
             );
-
-            Assert.Equal(
-                [
-                    PacketType.NicotvSetCommentVisibleResponse,
-                    PacketType.NotifyNicotvSetCommentVisible,
-                    PacketType.NicotvOpenResponse,
-                ],
-                actor.Sent.Select(p => p.Type)
-            );
-            Assert.Equal(
-                BuildUIntPayload(nicotvId, (uint)NicotvCommentVisibility.Hidden),
-                actor.Sent[1].Payload
-            );
-            var peerNotify = Assert.Single(peer.Sent);
-            Assert.Equal(PacketType.NotifyNicotvSetCommentVisible, peerNotify.Type);
-            Assert.Equal(
-                BuildUIntPayload(nicotvId, (uint)NicotvCommentVisibility.Hidden),
-                peerNotify.Payload
-            );
+            var only = Assert.Single(actor.Sent);
+            Assert.Equal(PacketType.NicotvOpenResponse, only.Type);
+            Assert.Empty(peer.Sent);
         }
         finally
         {

--- a/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
+++ b/tests/aisp.Common.Tests/AreaNicotvHandlersTests.cs
@@ -260,11 +260,13 @@ public sealed class AreaNicotvHandlersTests
 
             await using var db = new MainContext(options);
             var repository = new NicotvRepository(db);
+            // The TV starts switched off: tuning it is done without an open (open/close is the
+            // power toggle alone), and the client shows the channel at once.
             var nicotv = Assert.IsType<Nicotv>(
                 await repository.UpdateForFurnitureAsync(
                     42,
                     2,
-                    new NicotvData(playbackState: NicotvPlaybackState.Playing),
+                    new NicotvData(playbackState: NicotvPlaybackState.Closed),
                     ct
                 )
             );
@@ -294,6 +296,7 @@ public sealed class AreaNicotvHandlersTests
             Assert.Equal(PacketType.NotifyNicotvSetChannel, notification.Type);
             Assert.Equal(BuildUIntPayload(nicotvId, 1), notification.Payload);
             Assert.Equal(1u, nicotv.ChannelId);
+            Assert.Equal(NicotvPlaybackState.Playing, nicotv.PlaybackState);
 
             actor.Sent.Clear();
             peer.Sent.Clear();
@@ -439,6 +442,9 @@ public sealed class AreaNicotvHandlersTests
             );
             Assert.Equal(PacketType.NotifyNicotvSetMovie, Assert.Single(peer.Sent).Type);
             Assert.Equal("sm9", nicotv.MovieId);
+            // Setting a movie starts it: the TV was paused, and the client plays the new movie
+            // without any open or play request of its own.
+            Assert.Equal(NicotvPlaybackState.Playing, nicotv.PlaybackState);
 
             // Setting the movie also starts that room's shared timeline for it at zero. The
             // screen page round-trips the n: tag the handler appended, so that is how a

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -1210,6 +1210,132 @@ public class CmdExecHandlerTests
     }
 
     [Fact]
+    public async Task ChannelCommand_ReloadsTunedTvsThatAreOn_NotOnesSwitchedOff()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+        try
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var mod = CreateUserWithCharacter(1, 8004, "channel-mod", "Channel Mod", 20_000_000);
+            mod.Role = UserRole.Moderator;
+            await TestDb.SeedCharacterAsync(options, 42, ct);
+            int onTvId;
+            await using (var db = new MainContext(options))
+            {
+                db.Users.Add(mod);
+                db.Items.Add(
+                    new Item
+                    {
+                        Id = 11_000_591,
+                        Name = "ブラウン管TV（１９インチ）",
+                        IconId = 11_000_591,
+                    }
+                );
+                db.Furniture.Add(
+                    new Furniture
+                    {
+                        ItemId = 11_000_591,
+                        PlacementFlags = FurniturePlacementFlags.Floor,
+                    }
+                );
+                db.MyRoomFurniture.Add(
+                    new MyRoomFurniture
+                    {
+                        RoomId = 42,
+                        FurnitureId = 2,
+                        ItemId = 11_000_591,
+                    }
+                );
+                db.MyRoomFurniture.Add(
+                    new MyRoomFurniture
+                    {
+                        RoomId = 42,
+                        FurnitureId = 3,
+                        ItemId = 11_000_591,
+                    }
+                );
+                // Two TVs on channel 1 in the same room: one showing it, one switched off.
+                var on = new Nicotv
+                {
+                    RoomId = 42,
+                    FurnitureId = 2,
+                    ChannelId = 1,
+                    PlaybackState = NicotvPlaybackState.Playing,
+                };
+                db.Nicotvs.Add(on);
+                db.Nicotvs.Add(
+                    new Nicotv
+                    {
+                        RoomId = 42,
+                        FurnitureId = 3,
+                        ChannelId = 1,
+                        PlaybackState = NicotvPlaybackState.Closed,
+                    }
+                );
+                await db.SaveChangesAsync(ct);
+                onTvId = on.Id;
+            }
+
+            var state = new SharedState();
+            var viewer = new CapturingPlayerSession
+            {
+                User = mod,
+                UserId = mod.Id,
+                Character = mod.Characters.First(),
+                CharacterId = 8004,
+                MapId = 20_000_000,
+                MyRoomId = 42,
+                ChannelId = 1,
+            };
+            state.RegisterClient(ServerType.Area, viewer);
+            var msgSession = new CapturingPlayerSession { User = mod, UserId = mod.Id };
+
+            var handler = new CmdExecHandler(
+                state,
+                new MapRepository(new MainContext(options)),
+                new UserRepository(new MainContext(options)),
+                new CharacterRepository(
+                    new MainContext(options),
+                    NullLogger<CharacterRepository>.Instance
+                ),
+                new MyRoomRepository(new MainContext(options)),
+                new CircleRepository(new MainContext(options)),
+                new StubItemBaseListCache(DefaultClothingItems.Male),
+                CreateDirectMapLinkTransitionService(options, state),
+                CreateModerationService(options, state),
+                new ChatLogRepository(new MainContext(options)),
+                new ReportTicketRepository(new MainContext(options)),
+                TestTextLocaliser.English,
+                new AdventureWorkRepository(new MainContext(options)),
+                WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
+                Options.Create(new ServerOptions()),
+                NullLogger<CmdExecHandler>.Instance
+            );
+
+            await handler.HandleAsync(
+                BuildCmdExecPayload("channel", "1", "tw:someone"),
+                msgSession,
+                ct
+            );
+
+            // Only the TV that is on reloads; the one switched off would have been turned on by it.
+            var notify = Assert.Single(
+                viewer.Sent,
+                p => p.Type == PacketType.NotifyNicotvSetChannel
+            );
+            var reader = new PacketReader(notify.Payload);
+            Assert.Equal((uint)onTvId, reader.ReadUInt());
+            Assert.Equal(1u, reader.ReadUInt());
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public async Task GiveCommand_AddsItemToInventoryAndSendsItemCreateNotify()
     {
         var (connection, options) = TestDb.CreateInMemoryMainContext();

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -96,6 +96,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -227,6 +229,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -343,6 +347,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -443,6 +449,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -585,6 +593,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms(["faggot"]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -823,6 +833,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -901,6 +913,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -981,6 +995,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1053,6 +1069,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1143,6 +1161,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1236,6 +1256,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1328,6 +1350,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1401,6 +1425,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1530,6 +1556,8 @@ public class CmdExecHandlerTests
                 TestTextLocaliser.English,
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
+                new ScreenAssignments(),
+                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -2073,6 +2101,8 @@ public class CmdExecHandlerTests
             TestTextLocaliser.English,
             new AdventureWorkRepository(new MainContext(options)),
             WordFilter.FromTerms([]),
+            new ScreenAssignments(),
+            Options.Create(new ServerOptions()),
             NullLogger<CmdExecHandler>.Instance
         );
 

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -97,6 +97,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -230,6 +231,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -348,6 +350,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -450,6 +453,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -594,6 +598,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms(["faggot"]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -834,6 +839,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -914,6 +920,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -996,6 +1003,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1070,6 +1078,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1162,6 +1171,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1257,6 +1267,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1351,6 +1362,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1426,6 +1438,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -1557,6 +1570,7 @@ public class CmdExecHandlerTests
                 new AdventureWorkRepository(new MainContext(options)),
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
+                new NicotvRepository(new MainContext(options)),
                 Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
@@ -2079,6 +2093,108 @@ public class CmdExecHandlerTests
         }
     }
 
+    [Fact]
+    public async Task ChannelCommand_SetsContentAndRejectsNonModeratorsAndInvalidSources()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+
+        try
+        {
+            var mod = CreateUserWithCharacter(1, 9001, "moduser", "ModChar", 10990100);
+            mod.Role = UserRole.Moderator;
+            var player = CreateUserWithCharacter(2, 8001, "player", "PlayerChar", 10990100);
+
+            await using (var db = new MainContext(options))
+            {
+                db.Users.AddRange(mod, player);
+                await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+            }
+
+            var state = new SharedState();
+            var screenAssignments = new ScreenAssignments();
+            var handler = new CmdExecHandler(
+                state,
+                new MapRepository(new MainContext(options)),
+                new UserRepository(new MainContext(options)),
+                new CharacterRepository(
+                    new MainContext(options),
+                    NullLogger<CharacterRepository>.Instance
+                ),
+                new MyRoomRepository(new MainContext(options)),
+                new CircleRepository(new MainContext(options)),
+                new StubItemBaseListCache(),
+                CreateDirectMapLinkTransitionService(options, state),
+                CreateModerationService(options, state),
+                new ChatLogRepository(new MainContext(options)),
+                new ReportTicketRepository(new MainContext(options)),
+                TestTextLocaliser.English,
+                new AdventureWorkRepository(new MainContext(options)),
+                WordFilter.FromTerms([]),
+                screenAssignments,
+                new NicotvRepository(new MainContext(options)),
+                Options.Create(new ServerOptions()),
+                NullLogger<CmdExecHandler>.Instance
+            );
+
+            // A non-moderator is refused, and the channel stays unassigned.
+            var playerMsgSession = new CapturingPlayerSession { User = player, UserId = player.Id };
+            await handler.HandleAsync(
+                BuildCmdExecPayload("/channel", "2", "tw:someone"),
+                playerMsgSession,
+                TestContext.Current.CancellationToken
+            );
+            Assert.Null(screenAssignments.GetChannelSource(2));
+            var refusal = Assert.Single(
+                playerMsgSession.Sent,
+                packet => packet.Type == PacketType.TalkForwardNotify
+            );
+            var refusalReader = new PacketReader(refusal.Payload);
+            refusalReader.ReadUInt();
+            refusalReader.ReadUInt();
+            Assert.Contains(
+                "moderator",
+                refusalReader.ReadString("utf-8"),
+                StringComparison.OrdinalIgnoreCase
+            );
+
+            // A video (needs a shared timeline, which channels do not have) is rejected too.
+            var modMsgSession = new CapturingPlayerSession { User = mod, UserId = mod.Id };
+            await handler.HandleAsync(
+                BuildCmdExecPayload("/channel", "2", "yt:dQw4w9WgXcQ"),
+                modMsgSession,
+                TestContext.Current.CancellationToken
+            );
+            Assert.Null(screenAssignments.GetChannelSource(2));
+
+            // A moderator's livestream assignment sticks, normalised the same way /screen does.
+            await handler.HandleAsync(
+                BuildCmdExecPayload("/channel", "2", "tw:someone"),
+                modMsgSession,
+                TestContext.Current.CancellationToken
+            );
+            Assert.Equal("twitch:someone", screenAssignments.GetChannelSource(2));
+
+            // A room TV tuned to that channel (via channel:2, the same word /screen channel:2
+            // would bind a map to) resolves the assigned stream, not the title card.
+            Assert.Equal(
+                "streamlink:https://twitch.tv/someone",
+                screenAssignments.Resolve("room-tv", "channel:2 n:5", null)
+            );
+
+            // off clears it back to unassigned.
+            await handler.HandleAsync(
+                BuildCmdExecPayload("/channel", "2", "off"),
+                modMsgSession,
+                TestContext.Current.CancellationToken
+            );
+            Assert.Null(screenAssignments.GetChannelSource(2));
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
     private static CmdExecHandler CreateReportHandler(
         DbContextOptions<MainContext> options,
         SharedState state
@@ -2102,6 +2218,7 @@ public class CmdExecHandlerTests
             new AdventureWorkRepository(new MainContext(options)),
             WordFilter.FromTerms([]),
             new ScreenAssignments(),
+            new NicotvRepository(new MainContext(options)),
             Options.Create(new ServerOptions()),
             NullLogger<CmdExecHandler>.Instance
         );

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -252,7 +252,11 @@ public class CmdExecHandlerTests
             var reader = new PacketReader(notice.Payload);
             reader.ReadUInt();
             reader.ReadUInt();
-            Assert.Contains("target", reader.ReadString("utf-8"), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                "target",
+                reader.ReadString("utf-8"),
+                StringComparison.OrdinalIgnoreCase
+            );
         }
         finally
         {
@@ -670,14 +674,19 @@ public class CmdExecHandlerTests
                 msgSession,
                 TestContext.Current.CancellationToken
             );
-            var listNotice = Assert.Single(
-                msgSession.Sent,
-                packet => packet.Type == PacketType.TalkForwardNotify
+            // A list longer than one notice allows arrives as several; read them all.
+            var listText = string.Join(
+                "\n",
+                msgSession
+                    .Sent.Where(packet => packet.Type == PacketType.TalkForwardNotify)
+                    .Select(packet =>
+                    {
+                        var listReader = new PacketReader(packet.Payload);
+                        listReader.ReadUInt();
+                        listReader.ReadUInt();
+                        return listReader.ReadString("utf-8");
+                    })
             );
-            var listReader = new PacketReader(listNotice.Payload);
-            listReader.ReadUInt();
-            listReader.ReadUInt();
-            var listText = listReader.ReadString("utf-8");
             Assert.Contains("9000: Visitor's Default Room", listText, StringComparison.Ordinal);
             Assert.Contains(
                 $"{createdRoom.Id}: Second Room (8 tatami) [default]",

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -1,0 +1,177 @@
+using aisp.Common.Game;
+
+namespace aisp.Common.Tests;
+
+public sealed class ScreenAssignmentsTests
+{
+    [Fact]
+    public void RoomTv_PlaysTheTypedIds_OtherwiseTheMapAssignment()
+    {
+        var assignments = new ScreenAssignments();
+        assignments.Set(10990100, " twitch:someone ");
+
+        // A Twitch channel typed into the TV wins, whatever the map says; tw: is the short form.
+        Assert.Equal(
+            "streamlink:https://twitch.tv/me",
+            assignments.Resolve("room-tv", "twitch:me", 10990100)
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/averylongchannelname",
+            assignments.Resolve("room-tv", " tw:averylongchannelname ", null)
+        );
+        // twe: is the Twitch player embed in the off-screen browser.
+        Assert.Equal(
+            "electron:https://player.twitch.tv/?channel=ironmouse&parent=aisp.moe",
+            assignments.Resolve("room-tv", "twe:ironmouse", null)
+        );
+        // YouTube: ytl: is a live stream through streamlink.
+        Assert.Equal(
+            "streamlink:https://www.youtube.com/watch?v=jfKfPfyJRdk",
+            assignments.Resolve("room-tv", "ytl:jfKfPfyJRdk", null)
+        );
+        // Nico: a bare lv… id is a live programme through streamlink.
+        Assert.Equal(
+            "streamlink:https://live.nicovideo.jp/watch/lv351315472",
+            assignments.Resolve("room-tv", "lv351315472", 10990100)
+        );
+        Assert.Equal(
+            "streamlink:https://live.nicovideo.jp/watch/lv1",
+            assignments.Resolve("room-tv", "nico:lv1", null)
+        );
+        // The hook's test pattern; bare pattern is the same thing.
+        Assert.Equal("pattern:live", assignments.Resolve("room-tv", "pattern:live", null));
+        Assert.Equal("pattern:live", assignments.Resolve("room-tv", "pattern", null));
+        // The title card and the calibration grid can be typed too; the c: rectangles cannot.
+        Assert.Equal("title", assignments.Resolve("room-tv", "title", 10990100));
+        Assert.Equal("calibrate", assignments.Resolve("room-tv", "Calibrate", 10990100));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "c:0/0:10/10", null));
+        // Typed URLs and streams are not honoured: they would make every viewer fetch them.
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("room-tv", "stream:https://x/y.m3u8", 10990100)
+        );
+        Assert.Equal("blank", assignments.Resolve("room-tv", "https://example.test/", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "electron:https://x", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "streamlink:https://x/y", null));
+        // Ids with characters the sites do not use never reach a command line.
+        Assert.Equal("blank", assignments.Resolve("room-tv", "tw:some\"one", null));
+        // Anything else typed falls back to the map, then to blank.
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("room-tv", "Hello World", 10990100)
+        );
+        Assert.Equal("blank", assignments.Resolve("room-tv", "Hello World", 19001003));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "Hello World", null));
+        // testscreen always shows the diagnostic page, even on an assigned map.
+        Assert.Null(assignments.Resolve("room-tv", "testscreen", 10990100));
+        assignments.Set(19001003, "TestScreen");
+        Assert.Null(assignments.Resolve("live-watch", null, 19001003));
+    }
+
+    [Fact]
+    public void TownScreens_FollowTheMapAssignment_UntilCleared()
+    {
+        var assignments = new ScreenAssignments();
+        // Unassigned town screens show the title card.
+        Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
+
+        assignments.Set(10990100, "tw:someone");
+        // The page gets the hook's form; the stored assignment keeps the friendly one.
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("live-watch", null, 10990100)
+        );
+        Assert.Equal("twitch:someone", assignments.Get(10990100));
+        // The typed ids keep their friendly form in the assignment too.
+        assignments.Set(10990100, "pattern");
+        Assert.Equal("pattern:live", assignments.Get(10990100));
+
+        Assert.True(assignments.Clear(10990100));
+        Assert.False(assignments.Clear(10990100));
+        Assert.Equal("title", assignments.Resolve("live-watch", null, 10990100));
+    }
+
+    [Fact]
+    public void Sources_AreStreamsOrPages()
+    {
+        // The typed ids.
+        Assert.True(ScreenAssignments.IsTwitchSource("twitch:yueri"));
+        Assert.True(ScreenAssignments.IsTwitchSource("tw:yueri"));
+        Assert.False(ScreenAssignments.IsTwitchSource("tw:"));
+        Assert.False(ScreenAssignments.IsTwitchSource("tw:yue-ri"));
+        Assert.True(ScreenAssignments.IsTwitchEmbedSource("twe:ironmouse"));
+        Assert.True(ScreenAssignments.IsBrowserSource("twe:ironmouse"));
+        Assert.False(ScreenAssignments.IsTwitchSource("twe:ironmouse"));
+        Assert.True(ScreenAssignments.IsYouTubeLiveSource("ytl:jfKfPfyJRdk"));
+        Assert.False(ScreenAssignments.IsYouTubeLiveSource("ytl:"));
+        Assert.False(ScreenAssignments.IsYouTubeLiveSource("ytl:a/b"));
+        Assert.True(ScreenAssignments.IsNicoLiveSource("lv351315472"));
+        Assert.False(ScreenAssignments.IsNicoLiveId("lvx"));
+        Assert.False(ScreenAssignments.IsNicoLiveId("lv"));
+        Assert.True(ScreenAssignments.IsPatternSource("pattern:live"));
+        Assert.True(ScreenAssignments.IsPatternSource("pattern"));
+        Assert.False(ScreenAssignments.IsPatternSource("pattern:x"));
+        foreach (var typed in new[] { "tw:yueri", "twe:yueri", "ytl:abc", "lv1", "pattern:live" })
+        {
+            Assert.True(ScreenAssignments.IsTypedSource(typed), typed);
+            Assert.True(ScreenAssignments.IsStreamSource(typed), typed);
+            Assert.True(ScreenAssignments.IsValidSource(typed), typed);
+        }
+        // /screen only: URLs for streamlink, ffmpeg, the off-screen browser, and pages.
+        foreach (
+            var moderated in new[]
+            {
+                "streamlink:https://www.youtube.com/watch?v=x",
+                "stream:http://host/a.mp4",
+                "electron:https://example.com",
+            }
+        )
+        {
+            Assert.False(ScreenAssignments.IsTypedSource(moderated), moderated);
+            Assert.True(ScreenAssignments.IsStreamSource(moderated), moderated);
+            Assert.True(ScreenAssignments.IsValidSource(moderated), moderated);
+        }
+        Assert.False(ScreenAssignments.IsStreamSource("HTTP://host/page"));
+        Assert.True(ScreenAssignments.IsPageUrl("HTTP://host/page"));
+        Assert.True(ScreenAssignments.IsValidSource("HTTP://host/page"));
+        Assert.False(ScreenAssignments.IsTypedSource("HTTP://host/page"));
+        Assert.False(ScreenAssignments.IsPageUrl("twitch:yueri"));
+        // Not sources: the hook's own raw forms with nothing after the prefix, other schemes.
+        Assert.False(ScreenAssignments.IsValidSource("streamlink:"));
+        Assert.False(ScreenAssignments.IsValidSource("stream:"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:ftp://x"));
+        Assert.False(ScreenAssignments.IsElectronSource("https://example.com"));
+        Assert.True(ScreenAssignments.IsValidSource("testscreen"));
+        Assert.True(ScreenAssignments.IsValidSource("calibrate"));
+        Assert.True(ScreenAssignments.IsValidSource("title"));
+        Assert.True(ScreenAssignments.IsValidSource("blank"));
+        Assert.False(ScreenAssignments.IsValidSource("Hello World"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri twitch:other"));
+        Assert.False(ScreenAssignments.IsValidSource(null));
+        // The hook's forms.
+        Assert.Equal(
+            "streamlink:https://x/y",
+            ScreenAssignments.ToHookSource("streamlink:https://x/y")
+        );
+        Assert.Equal("pattern:live", ScreenAssignments.ToHookSource("Pattern"));
+        Assert.Equal("title", ScreenAssignments.ToHookSource("title"));
+        Assert.Equal(
+            "electron:https://player.twitch.tv/?channel=yueri&parent=aisp.moe",
+            ScreenAssignments.ToHookSource("twe:yueri")
+        );
+        Assert.Equal(
+            "streamlink:https://live.nicovideo.jp/watch/lv351315472",
+            ScreenAssignments.ToHookSource("lv351315472")
+        );
+        Assert.Equal(
+            "streamlink:https://www.youtube.com/watch?v=abc",
+            ScreenAssignments.ToHookSource("ytl:abc")
+        );
+        Assert.Equal("twitch:yueri", ScreenAssignments.Normalize(" tw:yueri "));
+    }
+}

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -463,6 +463,20 @@ public sealed class ScreenAssignmentsTests
     }
 
     [Fact]
+    public void NicotvTag_IsFoundAsAnExtraAndAsTheWholeMovieId()
+    {
+        // The server appends n:<id> to a TV's movie id; with no typed movie the tag is the whole
+        // id, which is the movieid= a powered-off-and-on channel TV comes back with.
+        Assert.True(ScreenAssignments.TryGetNicotvId("channel:2 n:9", out var tagged));
+        Assert.Equal(9u, tagged);
+        Assert.True(ScreenAssignments.TryGetNicotvId("n:3", out var alone));
+        Assert.Equal(3u, alone);
+        Assert.False(ScreenAssignments.TryGetNicotvId("sm11273499", out _));
+        Assert.False(ScreenAssignments.TryGetNicotvId("n:", out _));
+        Assert.False(ScreenAssignments.TryGetNicotvId(null, out _));
+    }
+
+    [Fact]
     public void Channels_AreSharedByNumber_LivestreamOnlyAndIndirectFromRoomTvsAndMaps()
     {
         // Livestream sources are valid channel content; a video (needs a timeline) or another

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -4,10 +4,19 @@ namespace aisp.Common.Tests;
 
 public sealed class ScreenAssignmentsTests
 {
+    private sealed class TestTime : TimeProvider
+    {
+        public DateTimeOffset Now = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
     [Fact]
     public void RoomTv_PlaysTheTypedIds_OtherwiseTheMapAssignment()
     {
-        var assignments = new ScreenAssignments();
+        var time = new TestTime();
+        var assignments = new ScreenAssignments(time);
+        var t0 = time.Now.ToUnixTimeSeconds();
         assignments.Set(10990100, " twitch:someone ");
 
         // A Twitch channel typed into the TV wins, whatever the map says; tw: is the short form.
@@ -24,12 +33,16 @@ public sealed class ScreenAssignmentsTests
             "electron:https://player.twitch.tv/?channel=ironmouse&parent=aisp.moe",
             assignments.Resolve("room-tv", "twe:ironmouse", null)
         );
-        // YouTube: ytl: is a live stream through streamlink.
+        // YouTube: ytl: is a live stream through streamlink, yt: a video through yt-dlp.
         Assert.Equal(
             "streamlink:https://www.youtube.com/watch?v=jfKfPfyJRdk",
             assignments.Resolve("room-tv", "ytl:jfKfPfyJRdk", null)
         );
-        // Nico: a bare lv… id is a live programme through streamlink.
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=dQw4w9WgXcQ start:{t0} offset:0",
+            assignments.Resolve("room-tv", "yt:dQw4w9WgXcQ", null)
+        );
+        // Nico: a bare lv… id is a live programme through streamlink, sm… a video through yt-dlp.
         Assert.Equal(
             "streamlink:https://live.nicovideo.jp/watch/lv351315472",
             assignments.Resolve("room-tv", "lv351315472", 10990100)
@@ -38,9 +51,17 @@ public sealed class ScreenAssignmentsTests
             "streamlink:https://live.nicovideo.jp/watch/lv1",
             assignments.Resolve("room-tv", "nico:lv1", null)
         );
-        // The hook's test pattern; bare pattern is the same thing.
+        Assert.Equal(
+            $"yt-dlp:https://www.nicovideo.jp/watch/sm11273499 start:{t0} offset:0",
+            assignments.Resolve("room-tv", "sm11273499", 10990100)
+        );
+        // The hook's test pattern, live or as a video on the shared timeline; bare pattern is live.
         Assert.Equal("pattern:live", assignments.Resolve("room-tv", "pattern:live", null));
         Assert.Equal("pattern:live", assignments.Resolve("room-tv", "pattern", null));
+        Assert.Equal(
+            $"pattern:vod start:{t0} offset:0",
+            assignments.Resolve("room-tv", "pattern:vod", 10990100)
+        );
         // The title card and the calibration grid can be typed too; the c: rectangles cannot.
         Assert.Equal("title", assignments.Resolve("room-tv", "title", 10990100));
         Assert.Equal("calibrate", assignments.Resolve("room-tv", "Calibrate", 10990100));
@@ -53,8 +74,11 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("blank", assignments.Resolve("room-tv", "https://example.test/", null));
         Assert.Equal("blank", assignments.Resolve("room-tv", "electron:https://x", null));
         Assert.Equal("blank", assignments.Resolve("room-tv", "streamlink:https://x/y", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "yt-dlp:https://x/y", null));
         // Ids with characters the sites do not use never reach a command line.
         Assert.Equal("blank", assignments.Resolve("room-tv", "tw:some\"one", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "yt:abc&x=1", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "smx", null));
         // Anything else typed falls back to the map, then to blank.
         Assert.Equal(
             "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/1000/12000/1/0",
@@ -66,6 +90,91 @@ public sealed class ScreenAssignmentsTests
         Assert.Null(assignments.Resolve("room-tv", "testscreen", 10990100));
         assignments.Set(19001003, "TestScreen");
         Assert.Null(assignments.Resolve("live-watch", null, 19001003));
+    }
+
+    [Fact]
+    public void Videos_CarryASharedTimeline_ThatPauseResumeAndSeekMove()
+    {
+        var time = new TestTime();
+        var assignments = new ScreenAssignments(time);
+        var t0 = time.Now.ToUnixTimeSeconds();
+        assignments.Set(30000001, "yt:abc123");
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=abc123 start:{t0} offset:0",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        // Ten seconds in, the words do not change: the position follows from start alone.
+        time.Now = time.Now.AddSeconds(10);
+        Assert.EndsWith(
+            $"start:{t0} offset:0",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        Assert.Equal(10, assignments.GetTimeline(30000001)!.PositionAt(time.Now));
+        // Pause: the position freezes at 10, the words gain the pause time.
+        Assert.True(assignments.Control(30000001, "pause"));
+        time.Now = time.Now.AddSeconds(5);
+        Assert.Equal(10, assignments.GetTimeline(30000001)!.PositionAt(time.Now));
+        Assert.EndsWith(
+            $"start:{t0} offset:0 paused:{t0 + 10}",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        // Resume: a new start at now with the paused position as offset.
+        Assert.True(assignments.Control(30000001, "resume"));
+        Assert.EndsWith(
+            $"start:{t0 + 15} offset:10",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        time.Now = time.Now.AddSeconds(2);
+        Assert.Equal(12, assignments.GetTimeline(30000001)!.PositionAt(time.Now));
+        // Seek while playing.
+        Assert.True(assignments.Control(30000001, "seek:100"));
+        Assert.EndsWith(
+            $"start:{t0 + 17} offset:100",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        // Not a video: nothing to control.
+        assignments.Set(30000001, "tw:someone");
+        Assert.False(assignments.Control(30000001, "pause"));
+        Assert.False(assignments.Control(30000002, "pause"));
+        // The other videos: a Nico video and the vod pattern.
+        assignments.Set(30000001, "sm9");
+        Assert.True(assignments.Control(30000001, "pause"));
+        assignments.Set(30000001, "pattern:vod");
+        Assert.True(assignments.Control(30000001, "seek:30"));
+        Assert.Equal(
+            $"pattern:vod start:{t0 + 17} offset:30",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        // A video typed into a room TV gets a timeline shared by that TV, in that room: map plus
+        // channel, since room instances reuse the same map id.
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=xyz start:{t0 + 17} offset:0",
+            assignments.Resolve("room-tv", "yt:xyz", 10990100, 1)
+        );
+        Assert.True(assignments.ControlMovie(10990100, 1, "yt:xyz", "pause"));
+        Assert.EndsWith($"paused:{t0 + 17}", assignments.Resolve("room-tv", "yt:xyz", 10990100, 1));
+        // A different room on the same map (another channel) does not share that pause.
+        Assert.DoesNotContain("paused:", assignments.Resolve("room-tv", "yt:xyz", 10990100, 2));
+        // Freshly setting the same id restarts that room's TV, even mid-playback.
+        assignments.SetMovie(10990100, 1, "yt:xyz");
+        Assert.EndsWith(
+            $"start:{t0 + 17} offset:0",
+            assignments.Resolve("room-tv", "yt:xyz", 10990100, 1)
+        );
+        Assert.True(assignments.ControlMovie(10990100, 1, "pattern:vod", "pause"));
+        Assert.EndsWith(
+            $"paused:{t0 + 17}",
+            assignments.Resolve("room-tv", "pattern:vod", 10990100, 1)
+        );
+        Assert.False(assignments.ControlMovie(10990100, 1, "pattern:live", "pause"));
+        Assert.False(assignments.ControlMovie(10990100, 1, "yt-dlp:https://x/y", "pause"));
+        Assert.False(assignments.ControlMovie(10990100, 1, "tw:someone", "pause"));
+        // SetMovie ignores anything that is not a video: no timeline appears for it.
+        assignments.SetMovie(10990100, 1, "tw:someone");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("room-tv", "tw:someone", 10990100, 1)
+        );
     }
 
     [Fact]
@@ -127,6 +236,8 @@ public sealed class ScreenAssignmentsTests
         );
         Assert.Equal("twitch:someone https://x/banner", assignments.Get(10990100));
         // The typed ids keep their friendly form in the assignment too.
+        assignments.Set(10990100, "sm9 pan");
+        Assert.Equal("nico:sm9 pan", assignments.Get(10990100));
         assignments.Set(10990100, "pattern");
         Assert.Equal("pattern:live", assignments.Get(10990100));
 
@@ -146,16 +257,43 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsTwitchEmbedSource("twe:ironmouse"));
         Assert.True(ScreenAssignments.IsBrowserSource("twe:ironmouse"));
         Assert.False(ScreenAssignments.IsTwitchSource("twe:ironmouse"));
+        Assert.True(ScreenAssignments.IsYouTubeVideoSource("yt:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsVideoSource("yt:dQw4w9WgXcQ"));
         Assert.True(ScreenAssignments.IsYouTubeLiveSource("ytl:jfKfPfyJRdk"));
-        Assert.False(ScreenAssignments.IsYouTubeLiveSource("ytl:"));
-        Assert.False(ScreenAssignments.IsYouTubeLiveSource("ytl:a/b"));
+        Assert.False(ScreenAssignments.IsVideoSource("ytl:jfKfPfyJRdk"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("yt:"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("yt:a/b"));
         Assert.True(ScreenAssignments.IsNicoLiveSource("lv351315472"));
+        Assert.True(ScreenAssignments.IsNicoVideoSource("sm11273499"));
+        Assert.True(ScreenAssignments.IsVideoSource("sm11273499"));
+        Assert.True(ScreenAssignments.IsNicoLiveVodId("lv351315472:vod"));
+        Assert.False(ScreenAssignments.IsNicoLiveVodId("lv351315472"));
+        Assert.True(ScreenAssignments.IsNicoLiveVodSource("lv351315472:vod"));
+        Assert.True(ScreenAssignments.IsVideoSource("lv351315472:vod"));
+        Assert.False(ScreenAssignments.IsNicoLiveSource("lv351315472:vod"));
         Assert.False(ScreenAssignments.IsNicoLiveId("lvx"));
         Assert.False(ScreenAssignments.IsNicoLiveId("lv"));
+        Assert.False(ScreenAssignments.IsNicoVideoId("sm"));
+        Assert.False(ScreenAssignments.IsNicoVideoId("smile"));
         Assert.True(ScreenAssignments.IsPatternSource("pattern:live"));
+        Assert.True(ScreenAssignments.IsPatternSource("pattern:vod"));
         Assert.True(ScreenAssignments.IsPatternSource("pattern"));
         Assert.False(ScreenAssignments.IsPatternSource("pattern:x"));
-        foreach (var typed in new[] { "tw:yueri", "twe:yueri", "ytl:abc", "lv1", "pattern:live" })
+        Assert.True(ScreenAssignments.IsVideoSource("pattern:vod"));
+        Assert.False(ScreenAssignments.IsVideoSource("pattern:live"));
+        foreach (
+            var typed in new[]
+            {
+                "tw:yueri",
+                "twe:yueri",
+                "yt:abc",
+                "ytl:abc",
+                "lv1",
+                "sm1",
+                "pattern:live",
+                "pattern:vod",
+            }
+        )
         {
             Assert.True(ScreenAssignments.IsTypedSource(typed), typed);
             Assert.True(ScreenAssignments.IsStreamSource(typed), typed);
@@ -180,7 +318,11 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsValidSource("HTTP://host/page"));
         Assert.False(ScreenAssignments.IsTypedSource("HTTP://host/page"));
         Assert.False(ScreenAssignments.IsPageUrl("twitch:yueri"));
-        // Not sources: the hook's own raw forms with nothing after the prefix, other schemes.
+        // Not sources: the hook's own raw yt-dlp form (yt: and sm… are the typed ways in), other
+        // browser hosts, and the raw forms with nothing after the prefix.
+        Assert.False(ScreenAssignments.IsValidSource("yt-dlp:https://x/y"));
+        Assert.False(ScreenAssignments.IsValidSource("cef:https://x"));
+        Assert.False(ScreenAssignments.IsValidSource("edge:https://x"));
         Assert.False(ScreenAssignments.IsValidSource("streamlink:"));
         Assert.False(ScreenAssignments.IsValidSource("stream:"));
         Assert.False(ScreenAssignments.IsValidSource("electron:"));
@@ -191,8 +333,8 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsValidSource("calibrate"));
         Assert.True(ScreenAssignments.IsValidSource("title"));
         Assert.True(ScreenAssignments.IsValidSource("blank"));
+        Assert.False(ScreenAssignments.IsValidSource("sm"));
         Assert.False(ScreenAssignments.IsValidSource("Hello World"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri twitch:other"));
         Assert.False(ScreenAssignments.IsValidSource(null));
         // The hook's forms.
         Assert.Equal(
@@ -200,14 +342,23 @@ public sealed class ScreenAssignmentsTests
             ScreenAssignments.ToHookSource("streamlink:https://x/y")
         );
         Assert.Equal("pattern:live", ScreenAssignments.ToHookSource("Pattern"));
+        Assert.Equal("pattern:vod", ScreenAssignments.ToHookSource("pattern:VOD"));
         Assert.Equal("title", ScreenAssignments.ToHookSource("title"));
         Assert.Equal(
             "electron:https://player.twitch.tv/?channel=yueri&parent=aisp.moe scroll:0/40",
             ScreenAssignments.ToHookSource("twe:yueri scroll:0/40")
         );
         Assert.Equal(
+            "yt-dlp:https://www.nicovideo.jp/watch/sm9",
+            ScreenAssignments.ToHookSource("sm9")
+        );
+        Assert.Equal(
             "streamlink:https://live.nicovideo.jp/watch/lv351315472",
             ScreenAssignments.ToHookSource("lv351315472")
+        );
+        Assert.Equal(
+            "yt-dlp:https://www.nicovideo.jp/watch/lv351315472",
+            ScreenAssignments.ToHookSource("lv351315472:vod")
         );
         Assert.Equal(
             "streamlink:https://www.youtube.com/watch?v=abc",
@@ -227,6 +378,7 @@ public sealed class ScreenAssignmentsTests
         Assert.False(ScreenAssignments.IsMainWord("main:x"));
         Assert.False(ScreenAssignments.IsValidSource("tw:yueri main:frame.html"));
         Assert.False(ScreenAssignments.IsValidSource("tw:yueri banner:ftp://x"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri twitch:other"));
         Assert.Equal(
             "streamlink:https://twitch.tv/yueri box:0/0/10/10 main:https://x/f",
             ScreenAssignments.ToHookSource("tw:yueri box:0/0/10/10 main:https://x/f")

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -473,6 +473,9 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsValidChannelContentSource("lv351315472"));
         Assert.True(ScreenAssignments.IsValidChannelContentSource("streamlink:https://x/y"));
         Assert.True(ScreenAssignments.IsValidChannelContentSource("pattern:live"));
+        // A web page is channel content too (the help has always said so): the screen page shows
+        // it over the video box, the same as a page given to /screen directly.
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("https://example.com/rain.html"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("yt:dQw4w9WgXcQ"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("sm11273499"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("lv351315472:vod"));
@@ -482,6 +485,9 @@ public sealed class ScreenAssignmentsTests
         // A channel is purely a source map: framing belongs on whoever references it, not here.
         Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone box:0/0/10/10"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone key"));
+        Assert.False(
+            ScreenAssignments.IsValidChannelContentSource("https://example.com/rain.html key")
+        );
 
         var assignments = new ScreenAssignments();
 

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -47,7 +47,7 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("blank", assignments.Resolve("room-tv", "c:0/0:10/10", null));
         // Typed URLs and streams are not honoured: they would make every viewer fetch them.
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone",
+            "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/1000/12000/1/0",
             assignments.Resolve("room-tv", "stream:https://x/y.m3u8", 10990100)
         );
         Assert.Equal("blank", assignments.Resolve("room-tv", "https://example.test/", null));
@@ -57,7 +57,7 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("blank", assignments.Resolve("room-tv", "tw:some\"one", null));
         // Anything else typed falls back to the map, then to blank.
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone",
+            "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/1000/12000/1/0",
             assignments.Resolve("room-tv", "Hello World", 10990100)
         );
         Assert.Equal("blank", assignments.Resolve("room-tv", "Hello World", 19001003));
@@ -76,13 +76,53 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
 
         assignments.Set(10990100, "tw:someone https://x/banner");
+        // Town screens also get the map's screen position for rolloff, unless the source names one.
+        Assert.EndsWith(
+            " rolloff:-17340/375/-20639/1000/12000/1/0",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        // The short form keeps the map's position and only sets the range; rolloff:flat turns
+        // the rolloff off; a short form on a map without a known screen is dropped.
+        assignments.Set(10990100, "tw:someone rolloff:500/6000");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/500/6000/1/0",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        // Four numbers add the gains to fade between, keeping the map's position.
+        assignments.Set(10990100, "tw:someone rolloff:500/6000/0.8/0.25");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/500/6000/0.8/0.25",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        assignments.Set(10990100, "tw:someone rolloff:flat");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        assignments.Set(30000001, "tw:someone rolloff:500/6000");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("channel-screen", null, 30000001)
+        );
+        assignments.Set(10990100, "tw:someone rolloff:1/2/3/10/20");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone rolloff:1/2/3/10/20/1/0",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        // Seven is the hook's own form and passes through unchanged.
+        assignments.Set(10990100, "tw:someone rolloff:1/2/3/10/20/0.5/0.1");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone rolloff:1/2/3/10/20/0.5/0.1",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        assignments.Set(10990100, "tw:someone https://x/banner");
         // The page gets the hook's form; the stored assignment keeps the friendly one.
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone https://x/banner",
+            "streamlink:https://twitch.tv/someone https://x/banner rolloff:-17340/375/-20639/1000/12000/1/0",
             assignments.Resolve("channel-screen", null, 10990100)
         );
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone https://x/banner",
+            "streamlink:https://twitch.tv/someone https://x/banner rolloff:-17340/375/-20639/1000/12000/1/0",
             assignments.Resolve("live-watch", null, 10990100)
         );
         Assert.Equal("twitch:someone https://x/banner", assignments.Get(10990100));
@@ -211,6 +251,29 @@ public sealed class ScreenAssignmentsTests
         Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:0/686:0/0"));
         Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972/686:-1/0"));
         Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972,686:0,0"));
+        // fps:N picks ffmpeg's constant output rate, from the set that maps to whole samples.
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri fps:60"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri fps:24"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri pan"));
+        var panned = new ScreenAssignments();
+        panned.Set(19001003, "tw:yueri pan");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/yueri pan rolloff:0/352.1/1567/1000/12000/1/0",
+            panned.Resolve("channel-screen", null, 19001003)
+        );
+        Assert.True(
+            ScreenAssignments.IsValidSource("tw:yueri rolloff:-17340/375/-20639/1000/12000")
+        );
+        Assert.True(
+            ScreenAssignments.IsValidSource("tw:yueri rolloff:-17340/375/-20639/1000/12000/1/0.2")
+        );
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri rolloff:1/2/3"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri rolloff:1/2/3/4/5/6"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:500/6000"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:500/6000/1/0.3"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:flat"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri audio:500/6000"));
+        Assert.Null(ScreenAssignments.DefaultRolloffWord(30000001));
         Assert.Equal(
             "streamlink:https://twitch.tv/yueri box:20/20/446/303",
             ScreenAssignments.ToHookSource("tw:yueri box:20/20/446/303")
@@ -236,6 +299,14 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal(
             "electron:https://example.com scroll:120/40",
             ScreenAssignments.ToHookSource("electron:https://example.com scroll:120/40")
+        );
+        // Town screens get the same default distance rolloff as other streams.
+        var electronTown = new ScreenAssignments();
+        electronTown.Set(10990100, "electron:https://example.com scrollx:16");
+        Assert.Equal(
+            "electron:https://example.com scrollx:16 "
+                + ScreenAssignments.DefaultRolloffWord(10990100),
+            electronTown.Resolve("channel-screen", null, 10990100)
         );
     }
 }

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -75,17 +75,17 @@ public sealed class ScreenAssignmentsTests
         // Unassigned town screens show the title card.
         Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
 
-        assignments.Set(10990100, "tw:someone");
+        assignments.Set(10990100, "tw:someone https://x/banner");
         // The page gets the hook's form; the stored assignment keeps the friendly one.
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone",
+            "streamlink:https://twitch.tv/someone https://x/banner",
             assignments.Resolve("channel-screen", null, 10990100)
         );
         Assert.Equal(
-            "streamlink:https://twitch.tv/someone",
+            "streamlink:https://twitch.tv/someone https://x/banner",
             assignments.Resolve("live-watch", null, 10990100)
         );
-        Assert.Equal("twitch:someone", assignments.Get(10990100));
+        Assert.Equal("twitch:someone https://x/banner", assignments.Get(10990100));
         // The typed ids keep their friendly form in the assignment too.
         assignments.Set(10990100, "pattern");
         Assert.Equal("pattern:live", assignments.Get(10990100));
@@ -147,6 +147,7 @@ public sealed class ScreenAssignmentsTests
         Assert.False(ScreenAssignments.IsValidSource("electron:ftp://x"));
         Assert.False(ScreenAssignments.IsElectronSource("https://example.com"));
         Assert.True(ScreenAssignments.IsValidSource("testscreen"));
+        Assert.True(ScreenAssignments.IsValidSource("pattern:live box:0/0/100/50"));
         Assert.True(ScreenAssignments.IsValidSource("calibrate"));
         Assert.True(ScreenAssignments.IsValidSource("title"));
         Assert.True(ScreenAssignments.IsValidSource("blank"));
@@ -161,8 +162,8 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("pattern:live", ScreenAssignments.ToHookSource("Pattern"));
         Assert.Equal("title", ScreenAssignments.ToHookSource("title"));
         Assert.Equal(
-            "electron:https://player.twitch.tv/?channel=yueri&parent=aisp.moe",
-            ScreenAssignments.ToHookSource("twe:yueri")
+            "electron:https://player.twitch.tv/?channel=yueri&parent=aisp.moe scroll:0/40",
+            ScreenAssignments.ToHookSource("twe:yueri scroll:0/40")
         );
         Assert.Equal(
             "streamlink:https://live.nicovideo.jp/watch/lv351315472",
@@ -172,6 +173,69 @@ public sealed class ScreenAssignmentsTests
             "streamlink:https://www.youtube.com/watch?v=abc",
             ScreenAssignments.ToHookSource("ytl:abc")
         );
-        Assert.Equal("twitch:yueri", ScreenAssignments.Normalize(" tw:yueri "));
+        // A bare second URL is the raw form (a banner page, or with a box a whole-crop frame
+        // page); main:<url> and banner:<url> name the panel. All three have to be pages.
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri https://example.test/banner"));
+        Assert.True(ScreenAssignments.IsValidSource("blank https://example.test/banner"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri banner:https://example.test/banner"));
+        Assert.True(
+            ScreenAssignments.IsValidSource(
+                "twe:ironmouse box:40/30/406/240 key main:https://example.test/frame.html banner:https://example.test/top"
+            )
+        );
+        Assert.True(ScreenAssignments.IsMainWord("main:http://x/"));
+        Assert.False(ScreenAssignments.IsMainWord("main:x"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri main:frame.html"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri banner:ftp://x"));
+        Assert.Equal(
+            "streamlink:https://twitch.tv/yueri box:0/0/10/10 main:https://x/f",
+            ScreenAssignments.ToHookSource("tw:yueri box:0/0/10/10 main:https://x/f")
+        );
+        // A box:x/y/w/h word places the video inside the crop; the page can put HTML around it.
+        // Slashes because the client splits chat arguments on commas.
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri https://x/ box:0/76/635/441"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri box:20/20"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri box:20,20,446,303"));
+        // key / key:RRGGBB colour-keys the video into the page's own pixels.
+        Assert.True(
+            ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303 key https://x/frame")
+        );
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri key:100010"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri key:12"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri key:zzzzzz"));
+        // crop:sw/sh:cx/cy renders at sw x sh and shows the box-sized window at cx,cy of it.
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri crop:972/686:243/171"));
+        Assert.True(ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303 crop:892/606:0/0"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972/686"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:0/686:0/0"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972/686:-1/0"));
+        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972,686:0,0"));
+        Assert.Equal(
+            "streamlink:https://twitch.tv/yueri box:20/20/446/303",
+            ScreenAssignments.ToHookSource("tw:yueri box:20/20/446/303")
+        );
+        Assert.Equal(
+            "twitch:yueri https://x/",
+            ScreenAssignments.Normalize(" tw:yueri  https://x/ ")
+        );
+        // Browser extras: scroll pans the document, scale is zoom.
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://example.com scrollx:120"));
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://example.com scrolly:40"));
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://example.com scroll:120/40"));
+        Assert.True(
+            ScreenAssignments.IsValidSource(
+                "electron:https://www.nicovideo.jp crop:800/600:50/0 scrollx:100 scale:0.75"
+            )
+        );
+        Assert.True(ScreenAssignments.IsValidSource("twe:yueri crop:800/600:0/0 scale:0.75"));
+        Assert.True(ScreenAssignments.IsScaleWord("scale:0.75"));
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://x scale:1"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:https://x scale:0"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:https://x scale:9"));
+        Assert.Equal(
+            "electron:https://example.com scroll:120/40",
+            ScreenAssignments.ToHookSource("electron:https://example.com scroll:120/40")
+        );
     }
 }

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -461,4 +461,123 @@ public sealed class ScreenAssignmentsTests
             electronTown.Resolve("channel-screen", null, 10990100)
         );
     }
+
+    [Fact]
+    public void Channels_AreSharedByNumber_LivestreamOnlyAndIndirectFromRoomTvsAndMaps()
+    {
+        // Livestream sources are valid channel content; a video (needs a timeline) or another
+        // channel (no indirection chains) is not.
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("tw:someone"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("twe:someone"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("ytl:abc"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("lv351315472"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("streamlink:https://x/y"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("pattern:live"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("yt:dQw4w9WgXcQ"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("sm11273499"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("lv351315472:vod"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("pattern:vod"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("channel:2"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("blank"));
+        // A channel is purely a source map: framing belongs on whoever references it, not here.
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone box:0/0/10/10"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone key"));
+
+        var assignments = new ScreenAssignments();
+
+        // Unassigned: a room TV's channel button and a map bound to it both show the title card.
+        Assert.Null(assignments.GetChannelSource(2));
+        Assert.Equal("title", assignments.Resolve("room-tv", "channel:2 n:9", null));
+        assignments.Set(10990100, "channel:2");
+        Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
+
+        // Assigning the channel is what both a room TV tuned to it and a map bound to it follow,
+        // with no further wiring: it is the same channel:2 word either way.
+        assignments.SetChannelSource(2, "tw:someone");
+        // Normalized to its long form, like any other assignment.
+        Assert.Equal("twitch:someone", assignments.GetChannelSource(2));
+        // A live source drops any extras on the reference (n: included), same as any other
+        // typed, non-video room-tv source already does: it needs no shared timeline to key.
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            assignments.Resolve("room-tv", "channel:2 n:9", null)
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone "
+                + ScreenAssignments.DefaultRolloffWord(10990100),
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+
+        // Framing extras on the reference (/screen channel:2 box:... key main:...) survive
+        // indirection: only the channel: word is swapped for the channel's own main token, so
+        // the same channel can be framed differently on different screens.
+        assignments.Set(
+            10990200,
+            "channel:2 box:40/30/406/240 key main:https://example.com/vnframe.html"
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone box:40/30/406/240 key main:https://example.com/vnframe.html "
+                + ScreenAssignments.DefaultRolloffWord(10990200),
+            assignments.Resolve("channel-screen", null, 10990200)
+        );
+
+        // GetMapsBoundToChannel finds every map bound to it, and only that channel.
+        assignments.Set(19001003, "channel:2");
+        assignments.Set(30000001, "channel:3");
+        Assert.Equal(
+            [10990100u, 10990200u, 19001003u],
+            assignments.GetMapsBoundToChannel(2).Order()
+        );
+        Assert.Equal([30000001u], assignments.GetMapsBoundToChannel(3));
+
+        // Clearing it falls back to the title card again on both sides.
+        Assert.True(assignments.ClearChannelSource(2));
+        Assert.Null(assignments.GetChannelSource(2));
+        Assert.Equal("title", assignments.Resolve("room-tv", "channel:2 n:9", null));
+        Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
+    }
+
+    [Fact]
+    public void ChannelAuto_FollowsTheRequestingScreensOwnTvid_ButNeverOverridesAnExplicitSource()
+    {
+        Assert.True(ScreenAssignments.IsValidSource("channel:auto"));
+        Assert.True(ScreenAssignments.IsChannelSource("channel:auto"));
+
+        var assignments = new ScreenAssignments();
+        assignments.SetChannelSource(1, "tw:one");
+
+        // No tvid= on the request at all: an unassigned map shows the title card, for the routes
+        // and requests that never carry one (live-watch, screen, or a channel-screen request
+        // without it).
+        Assert.Equal("title", assignments.Resolve("channel-screen", null, 40000001));
+
+        // An unassigned map defaults to channel:auto: it follows the requesting screen's own
+        // tvid=, without needing an explicit /screen channel:auto first. (These map ids have no
+        // registered screen position, so no default rolloff word is added either way here.)
+        Assert.Equal(
+            "streamlink:https://twitch.tv/one",
+            assignments.Resolve("channel-screen", null, 40000001, requestTvId: 1)
+        );
+        // A requesting tvid= for an unassigned channel still falls back to the title card.
+        Assert.Equal(
+            "title",
+            assignments.Resolve("channel-screen", null, 40000001, requestTvId: 5)
+        );
+
+        // Explicit /screen channel:auto behaves identically to the unassigned default.
+        assignments.Set(40000002, "channel:auto");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/one",
+            assignments.Resolve("channel-screen", null, 40000002, requestTvId: 1)
+        );
+
+        // An explicit, non-channel /screen assignment always wins over the requesting screen's
+        // own tvid=: a moderator's direct assignment is authoritative, and a town screen's own
+        // tvid= must never override it.
+        assignments.Set(40000003, "tw:two");
+        Assert.Equal(
+            "streamlink:https://twitch.tv/two",
+            assignments.Resolve("channel-screen", null, 40000003, requestTvId: 1)
+        );
+    }
 }

--- a/tests/aisp.Common.Tests/SystemNoticeTests.cs
+++ b/tests/aisp.Common.Tests/SystemNoticeTests.cs
@@ -1,0 +1,43 @@
+using System.Text;
+using aisp.Common.Game;
+using Xunit;
+
+namespace aisp.Common.Tests;
+
+public class SystemNoticeTests
+{
+    [Fact]
+    public void Messages_KeepEveryMessageUnderTheClientLimit()
+    {
+        var usage =
+            "/screen <source> [extras]. Sources: twitch:<channel> (or tw:), lv<id> (Nico Live), stream:<url>, a web page URL,\n"
+            + "fps:N (15/20/25/30/50/60), rolloff:near/far, rolloff:near/far/max/min (gains to fade between, default 1/0), rolloff:x/y/z/near/far, rolloff:x/y/z/near/far/max/min or rolloff:flat, pan to also stereo-pan by bearing.";
+        usage = usage + "\n" + usage + "\n" + usage;
+        var lines = SystemNotice.Messages(usage).ToList();
+        Assert.True(lines.Count >= 2);
+        Assert.All(
+            lines,
+            line => Assert.True(Encoding.UTF8.GetByteCount(line) <= SystemNotice.MaxLineBytes)
+        );
+        // Nothing lost: the words come back in order.
+        Assert.Equal(
+            usage.Replace("\n", " ").Split(' ', StringSplitOptions.RemoveEmptyEntries),
+            string.Join(' ', lines)
+                .Replace("\n", " ")
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+        );
+        // Short multi-line notices stay one message, with their line breaks.
+        Assert.Equal(new[] { "1 alice\n2 bob" }, SystemNotice.Messages("1 alice\n2 bob").ToList());
+    }
+
+    [Fact]
+    public void Messages_SplitLongWordsOnCharacterBoundaries()
+    {
+        var url = "https://example.test/" + new string('あ', 80);
+        var lines = SystemNotice.Messages(url, 40).ToList();
+        Assert.True(lines.Count > 1);
+        Assert.All(lines, line => Assert.True(Encoding.UTF8.GetByteCount(line) <= 40));
+        Assert.Equal(url, string.Concat(lines));
+        Assert.Equal(new[] { "short" }, SystemNotice.Messages("short").ToList());
+    }
+}


### PR DESCRIPTION
This adds the emulator side of the screen support. Depends on the launcher hook redirect and secondary source support.

Due to webpages nowadays refusing to load in iframes, and other content currently being easier through ffmpeg, this introduces a mechanism to overlay or composite a secondary rendering source on top of the webpage. This also ensures the main stage can be layouted properly.

Currently the secondary rendering source in the hook supports electron, ffmpeg, yt-dlp, and streamlink. The main webpage is still rendered using the stock browser, and can also render content from the same host through iframes, which can be used for the stage's top banner.

To support overlays, the hook allows setting a colorkey. The secondary rendering source will be visible wherever this colorkey appears on the primary browser output.

For the Room TV, the following short source identifiers are supported (limited label entry, and don't allow user URLs). The emulator converts them to the proper full URL format.

<img width="972" height="623" alt="Screenshot 2026-09-04 163427" src="https://github.com/user-attachments/assets/2fa144e6-b0fa-4dce-aa81-426f33bc6af8" />

For main TVs outdoors and on the stage, `/screen` and `/channel` commands are added to provide control over the screens and channels. By default there are 5 channels (0-4) which are selected as `/screen channel:auto` or `channel:1` etc on each of the outdoor TVs, which are the same channels that can be selected on the room TVs. By default, Akiba is channel 0, the other side of Akiba is channel 1, etcetera. The channels are simply a virtual table of livestreams that can be configured like `/channel 0 twe:kaetemi`, and are synchronized to all the TVs running on that channel.

The outdoor screens can be further configured using the `/screen` command to configure framing, audio distance rollof, etc.

## Examples

Place stack of TVs in room. Issue `/channel 1 https://example.com/matrix.com`, set TVs to channel 1 (push channel button), set some other TVs to `tw:example` or `twe:example` (NOTE: Need to close the TV control window before clicking the next TV.)

This loads the matrix rain in a regular iframe, the 'tw' sources using ffmpeg as overlay, and the 'twe' sources using electron as overlay, all fully covering the screen page.

<img width="1515" height="1130" alt="image" src="https://github.com/user-attachments/assets/a3c50c5c-e874-4e17-9c21-0db18b8d2c64" />

todo doc rest of screen command