### PR TITLE
Support embed versions of streams

### DIFF
--- a/aisp.Common/Config/ScreenOptions.cs
+++ b/aisp.Common/Config/ScreenOptions.cs
@@ -10,4 +10,12 @@ public sealed class ScreenOptions
     /// <summary>yt:&lt;id&gt;: "electron" (YouTube's own player in the off-screen browser, as yte:)
     /// or "yt-dlp" (resolved by yt-dlp and decoded by ffmpeg, as ytd:).</summary>
     public string YouTube { get; set; } = "electron";
+
+    /// <summary>sm… (nn:sm…): "electron" (Nico's own player embed in the off-screen browser, as nne:)
+    /// or "yt-dlp" (resolved by yt-dlp and decoded by ffmpeg, as nnd:).</summary>
+    public string NicoVideo { get; set; } = "electron";
+
+    /// <summary>lv… (nn:lv…): "electron" (the Nico Live watch page in the off-screen browser with its
+    /// player scaled to the box, as nne:) or "streamlink" (decoded through streamlink and ffmpeg, as nnl:).</summary>
+    public string NicoLive { get; set; } = "electron";
 }

--- a/aisp.Common/Config/ScreenOptions.cs
+++ b/aisp.Common/Config/ScreenOptions.cs
@@ -1,0 +1,13 @@
+namespace aisp.Common.Config;
+
+/// <summary>How the short screen ids that leave the choice to the server play (ScreenAssignments).</summary>
+public sealed class ScreenOptions
+{
+    /// <summary>tw:&lt;channel&gt;: "electron" (Twitch's own player in the off-screen browser, as twe:)
+    /// or "streamlink" (decoded through streamlink and ffmpeg, as twl:).</summary>
+    public string Twitch { get; set; } = "electron";
+
+    /// <summary>yt:&lt;id&gt;: "electron" (YouTube's own player in the off-screen browser, as yte:)
+    /// or "yt-dlp" (resolved by yt-dlp and decoded by ffmpeg, as ytd:).</summary>
+    public string YouTube { get; set; } = "electron";
+}

--- a/aisp.Common/Config/ServerOptions.cs
+++ b/aisp.Common/Config/ServerOptions.cs
@@ -8,6 +8,9 @@ public class ServerOptions
     public DbOptions DbOptions { get; set; } = new();
     public NicoLiveOptions NicoLive { get; set; } = new();
 
+    /// <summary>How tw: and yt: play: Twitch's/YouTube's own embed (default) or the decoded stream.</summary>
+    public ScreenOptions Screens { get; set; } = new();
+
     /// <summary>Bounded capacity for each game server's packet dispatch channel (Auth, Msg, Area). Producers wait when full.</summary>
     public int PacketChannelCapacity { get; set; } = 512;
 
@@ -49,6 +52,7 @@ public class ServerOptions
 
     /// <summary>Price of one 原稿用紙 (manuscript sheet) in デレ (the in-game currency) at the sheet shop the drama editor's 通販 button opens.</summary>
     public long AdventureSheetPriceAi { get; set; } = 10;
+
     /// <summary>Weekly settlement of drama disc sales: when the author's share of each sale, in デレ (the in-game currency), becomes collectable from the shop's 売上 clerk.</summary>
     public AdventureSettlementOptions AdventureSettlement { get; set; } = new();
 

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -237,6 +237,19 @@ public sealed class ScreenAssignments(
                     timeline.Paused ? "&paused=" + timeline.PausedAt!.Value.ToUnixTimeSeconds() : ""
                 );
         }
+        // The Nico watch page gets the same numbers as a fragment, which the site ignores and
+        // the run: script reads (a changed fragment is a changed URL: a restart at the position).
+        else if (words[0].StartsWith("electron:" + NicoVideoWatchPage, StringComparison.Ordinal))
+        {
+            words[0] +=
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"#start={timeline.StartedAt.ToUnixTimeSeconds()}&offset={timeline.Offset:0.###}"
+                )
+                + (
+                    timeline.Paused ? "&paused=" + timeline.PausedAt!.Value.ToUnixTimeSeconds() : ""
+                );
+        }
         words.Add(TimelineWords(timeline));
         return string.Join(' ', words);
     }
@@ -351,7 +364,9 @@ public sealed class ScreenAssignments(
         if (main.StartsWith("twitch:", StringComparison.OrdinalIgnoreCase))
             main = "tw:" + main[7..];
         else if (IsNicoLiveId(main) || IsNicoVideoId(main) || IsNicoLiveVodId(main))
-            main = "nico:" + main;
+            main = "nn:" + main;
+        else if (main.StartsWith("nico:", StringComparison.OrdinalIgnoreCase))
+            main = "nn:" + main[5..];
         else if (string.Equals(main, "pattern", StringComparison.OrdinalIgnoreCase))
             main = PatternLive;
         else if (
@@ -641,18 +656,57 @@ public sealed class ScreenAssignments(
     public static bool IsTwitchStreamlinkSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "twl:", IsTwitchChannel);
 
-    /// <summary>nico:lv… (a bare lv… id): a Nico Live programme through streamlink.</summary>
+    /// <summary>nn:lv… (a bare lv… id, or nico:lv…): a Nico Live programme, as the watch page in the
+    /// off-screen browser or through streamlink as the server is configured (<see cref="ScreenSourceDefaults"/>).</summary>
     public static bool IsNicoLiveSource(string? source) =>
-        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoLiveId);
+        source is not null && HasPrefix(MainOf(source), "nn:", IsNicoLiveId);
 
-    /// <summary>nico:lv…:vod (see <see cref="IsNicoLiveVodId"/>): the archive through yt-dlp,
-    /// with a shared timeline, instead of live through streamlink.</summary>
+    /// <summary>nn:lv…:vod (see <see cref="IsNicoLiveVodId"/>): the archive through yt-dlp,
+    /// with a shared timeline, instead of live.</summary>
     public static bool IsNicoLiveVodSource(string? source) =>
-        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoLiveVodId);
+        source is not null && HasPrefix(MainOf(source), "nn:", IsNicoLiveVodId);
 
-    /// <summary>nico:sm… (a bare sm… id): a Nico video through yt-dlp, with a shared timeline.</summary>
+    /// <summary>nn:sm… (a bare sm… id, or nico:sm…): a Nico video with a shared timeline, as the
+    /// embed or through yt-dlp as the server is configured (<see cref="ScreenSourceDefaults"/>).</summary>
     public static bool IsNicoVideoSource(string? source) =>
-        source is not null && HasPrefix(MainOf(source), "nico:", IsNicoVideoId);
+        source is not null && HasPrefix(MainOf(source), "nn:", IsNicoVideoId);
+
+    /// <summary>nnd:sm… or nnd:lv…:vod: a Nico video, or an archived programme, through yt-dlp.</summary>
+    public static bool IsNicoDlpSource(string? source) =>
+        source is not null
+        && HasPrefix(MainOf(source), "nnd:", rest => IsNicoVideoId(rest) || IsNicoLiveVodId(rest));
+
+    /// <summary>nnl:lv…: a Nico Live programme through streamlink.</summary>
+    public static bool IsNicoStreamlinkSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nnl:", IsNicoLiveId);
+
+    /// <summary>
+    /// nne:sm…: a Nico video as its own watch page in the off-screen browser, looping. Nico's
+    /// player embed failed on some machines where the watch page plays, so the page is loaded
+    /// whole and a run: script (<see cref="NicoVideoPlayerScript"/>) pins the page's own video
+    /// element over the viewport (the video box) and drives it: the shared timeline rides in the
+    /// page URL's fragment, which the site ignores.
+    /// </summary>
+    public static bool IsNicoEmbedVideoSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nne:", IsNicoVideoId);
+
+    /// <summary>
+    /// nne:lv…: a Nico Live programme as its own watch page in the off-screen browser. Nico has no
+    /// embeddable live player any more and the page refuses framing, so the page is loaded whole
+    /// and a run: script (<see cref="NicoLivePlayerScript"/>) presses its player's own
+    /// fullscreen button, which scales the player to the viewport, the video box.
+    /// </summary>
+    public static bool IsNicoEmbedLiveSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "nne:", IsNicoLiveId);
+
+    /// <summary>The root-relative script nne:sm… runs in the watch page (a run: word).</summary>
+    public const string NicoVideoPlayerScript = "/ai-sp/run/nicovideo-player.js";
+
+    /// <summary>The page nne:sm… loads, before the id and the timeline fragment.</summary>
+    public const string NicoVideoWatchPage = "https://www.nicovideo.jp/watch/";
+
+    /// <summary>The root-relative script nne:lv… runs in the watch page (a run: word).</summary>
+    public const string NicoLivePlayerScript = "/ai-sp/run/nicolive-player.js";
 
     /// <summary>yt:&lt;id&gt;: a YouTube video with a shared timeline, as the embed or through
     /// yt-dlp as the server is configured (<see cref="ScreenSourceDefaults"/>).</summary>
@@ -703,8 +757,12 @@ public sealed class ScreenAssignments(
         return IsElectronSource(source)
             || IsTwitchEmbedSource(source)
             || IsYouTubeEmbedSource(source)
+            || IsNicoEmbedVideoSource(source)
+            || IsNicoEmbedLiveSource(source)
             || (d.TwitchEmbed && IsTwitchSource(source))
-            || (d.YouTubeEmbed && IsYouTubeVideoSource(source));
+            || (d.YouTubeEmbed && IsYouTubeVideoSource(source))
+            || (d.NicoVideoEmbed && IsNicoVideoSource(source))
+            || (d.NicoLiveEmbed && IsNicoLiveSource(source));
     }
 
     /// <summary>
@@ -748,14 +806,16 @@ public sealed class ScreenAssignments(
         && (IsStreamSource(source) || IsPageUrl(source))
         && !IsChannelSource(source);
 
-    /// <summary>A video with a shared timeline (not a live stream): yt:, yte:, ytd:, sm… and
-    /// pattern:vod. The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
+    /// <summary>A video with a shared timeline (not a live stream): yt:, yte:, ytd:, sm… (nn:, nne:,
+    /// nnd:), lv…:vod and pattern:vod. The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
     public static bool IsVideoSource(string? source) =>
         IsYouTubeVideoSource(source)
         || IsYouTubeEmbedSource(source)
         || IsYouTubeDlpSource(source)
         || IsNicoVideoSource(source)
         || IsNicoLiveVodSource(source)
+        || IsNicoDlpSource(source)
+        || IsNicoEmbedVideoSource(source)
         || (
             source is not null
             && string.Equals(MainOf(source), PatternVod, StringComparison.OrdinalIgnoreCase)
@@ -770,6 +830,8 @@ public sealed class ScreenAssignments(
         || IsTwitchEmbedSource(source)
         || IsTwitchStreamlinkSource(source)
         || IsNicoLiveSource(source)
+        || IsNicoStreamlinkSource(source)
+        || IsNicoEmbedLiveSource(source)
         || IsYouTubeLiveSource(source)
         || IsVideoSource(source)
         || IsPatternSource(source)
@@ -862,6 +924,13 @@ public sealed class ScreenAssignments(
             main = (d.TwitchEmbed ? "twe:" : "twl:") + main[3..];
         else if (IsYouTubeVideoSource(main))
             main = (d.YouTubeEmbed ? "yte:" : "ytd:") + main[3..];
+        else if (IsNicoVideoSource(main))
+            main = (d.NicoVideoEmbed ? "nne:" : "nnd:") + main[3..];
+        else if (IsNicoLiveVodSource(main))
+            main = "nnd:" + main[3..];
+        else if (IsNicoLiveSource(main))
+            main = (d.NicoLiveEmbed ? "nne:" : "nnl:") + main[3..];
+        var extras = words.Skip(1).ToList();
         if (IsTwitchStreamlinkSource(main))
             main = "streamlink:https://twitch.tv/" + main[4..];
         else if (IsTwitchEmbedSource(main))
@@ -870,19 +939,33 @@ public sealed class ScreenAssignments(
                 + main[4..]
                 + "&parent="
                 + TwitchEmbedParent;
-        else if (IsNicoLiveVodSource(main))
-            main = "yt-dlp:https://www.nicovideo.jp/watch/" + main[5..^4];
-        else if (IsNicoLiveSource(main))
-            main = "streamlink:https://live.nicovideo.jp/watch/" + main[5..];
-        else if (IsNicoVideoSource(main))
-            main = "yt-dlp:https://www.nicovideo.jp/watch/" + main[5..];
+        else if (IsNicoDlpSource(main))
+            main =
+                "yt-dlp:https://www.nicovideo.jp/watch/"
+                + (IsNicoLiveVodId(main[4..]) ? main[4..^4] : main[4..]);
+        else if (IsNicoStreamlinkSource(main))
+            main = "streamlink:https://live.nicovideo.jp/watch/" + main[4..];
+        else if (IsNicoEmbedVideoSource(main))
+        {
+            main = "electron:" + NicoVideoWatchPage + main[4..];
+            if (!extras.Any(IsRunWord))
+                extras.Insert(0, "run:" + NicoVideoPlayerScript);
+        }
+        else if (IsNicoEmbedLiveSource(main))
+        {
+            main = "electron:https://live.nicovideo.jp/watch/" + main[4..];
+            // The page's own player, scaled to the box by the script; a run: word of the
+            // caller's own wins.
+            if (!extras.Any(IsRunWord))
+                extras.Insert(0, "run:" + NicoLivePlayerScript);
+        }
         else if (IsYouTubeDlpSource(main))
             main = "yt-dlp:https://www.youtube.com/watch?v=" + main[4..];
         else if (IsYouTubeEmbedSource(main))
             main = "electron:" + YouTubeEmbedPage + "?v=" + main[4..];
         else if (IsYouTubeLiveSource(main))
             main = "streamlink:https://www.youtube.com/watch?v=" + main[4..];
-        return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
+        return string.Join(' ', new[] { main }.Concat(extras));
     }
 
     /// <summary>
@@ -1014,7 +1097,12 @@ public sealed class ScreenAssignments(
 /// own player than to yt-dlp. From the server's [Server:Screens] settings, whose values are the
 /// hook sources each becomes: electron, streamlink, yt-dlp.
 /// </summary>
-public sealed record ScreenSourceDefaults(bool TwitchEmbed = true, bool YouTubeEmbed = true)
+public sealed record ScreenSourceDefaults(
+    bool TwitchEmbed = true,
+    bool YouTubeEmbed = true,
+    bool NicoVideoEmbed = true,
+    bool NicoLiveEmbed = true
+)
 {
     public static readonly ScreenSourceDefaults Default = new();
 
@@ -1028,6 +1116,16 @@ public sealed record ScreenSourceDefaults(bool TwitchEmbed = true, bool YouTubeE
             YouTubeEmbed: !string.Equals(
                 options.YouTube,
                 "yt-dlp",
+                StringComparison.OrdinalIgnoreCase
+            ),
+            NicoVideoEmbed: !string.Equals(
+                options.NicoVideo,
+                "yt-dlp",
+                StringComparison.OrdinalIgnoreCase
+            ),
+            NicoLiveEmbed: !string.Equals(
+                options.NicoLive,
+                "streamlink",
                 StringComparison.OrdinalIgnoreCase
             )
         );

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Globalization;
+using aisp.Common.Config;
 
 namespace aisp.Common.Game;
 
@@ -11,17 +12,23 @@ namespace aisp.Common.Game;
 /// map, set with the /screen chat command.
 ///
 /// The ids anyone may type into a room TV (fetched by every viewer's client, so only short ids
-/// that expand to a known site): title, pattern:live, pattern:vod, tw:&lt;channel&gt; (Twitch
-/// through streamlink), twe:&lt;channel&gt; (the Twitch player embed in the off-screen browser),
-/// yt:&lt;id&gt; (a YouTube video through yt-dlp), ytl:&lt;id&gt; (a YouTube live through
-/// streamlink), lv… (Nico Live through streamlink), lv…:vod (the same, once archived, as a
-/// video through yt-dlp instead) and sm… (a Nico video through yt-dlp).
+/// that expand to a known site): title, pattern:live, pattern:vod, twe:&lt;channel&gt; (the Twitch
+/// player embed in the off-screen browser), twl:&lt;channel&gt; (Twitch through streamlink),
+/// tw:&lt;channel&gt; (either, as the server is configured: <see cref="ScreenSourceDefaults"/>),
+/// yte:&lt;id&gt; (a YouTube video as YouTube's own embed in the off-screen browser, looping),
+/// ytd:&lt;id&gt; (the same through yt-dlp), yt:&lt;id&gt; (either, as configured), ytl:&lt;id&gt;
+/// (a YouTube live through streamlink), lv… (Nico Live through streamlink), lv…:vod (the same,
+/// once archived, as a video through yt-dlp instead) and sm… (a Nico video through yt-dlp).
 /// Only /screen takes streamlink:&lt;url&gt;, stream:&lt;url&gt;, electron:&lt;url&gt; and a
 /// web page URL.
 /// </summary>
-public sealed class ScreenAssignments(TimeProvider? time = null)
+public sealed class ScreenAssignments(
+    TimeProvider? time = null,
+    ScreenSourceDefaults? defaults = null
+)
 {
     private readonly TimeProvider _time = time ?? TimeProvider.System;
+    private readonly ScreenSourceDefaults _defaults = defaults ?? ScreenSourceDefaults.Default;
     private readonly ConcurrentDictionary<uint, Entry> _byMap = new();
 
     // Timelines of videos typed into room TVs, by the furniture's own database id where known
@@ -199,6 +206,29 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         return null;
     }
 
+    /// <summary>
+    /// The hook source of a video with its timeline: the start/offset/paused words for the page
+    /// to publish, and for the YouTube embed the same values in its page URL, since the
+    /// off-screen browser only gets the URL (and a changed URL restarts it at the new position).
+    /// </summary>
+    private static string WithTimeline(string hookSource, Timeline timeline)
+    {
+        var words = hookSource.Split(' ').ToList();
+        if (words[0].StartsWith("electron:" + YouTubeEmbedPage + "?", StringComparison.Ordinal))
+        {
+            words[0] +=
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"&start={timeline.StartedAt.ToUnixTimeSeconds()}&offset={timeline.Offset:0.###}"
+                )
+                + (
+                    timeline.Paused ? "&paused=" + timeline.PausedAt!.Value.ToUnixTimeSeconds() : ""
+                );
+        }
+        words.Add(TimelineWords(timeline));
+        return string.Join(' ', words);
+    }
+
     private static string TimelineWords(Timeline timeline) =>
         string.Create(
             CultureInfo.InvariantCulture,
@@ -241,8 +271,8 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     public const uint StageMapId = 19_001_003;
 
     /// <summary>
-    /// Canonical form of a source: trimmed, with the typed short ids expanded to their prefixed
-    /// forms (tw: to twitch:, a bare lv… or sm… id to nico:, bare pattern to pattern:live). A
+    /// Canonical form of a source: trimmed, with the typed short ids in their prefixed forms
+    /// (twitch: to tw:, a bare lv… or sm… id to nico:, bare pattern to pattern:live). A
     /// source is "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
     /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]] [fps:N]
     /// [rolloff:…] [pan]": main:&lt;url&gt; is a frame page under the main panel, with the box
@@ -259,8 +289,8 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         if (words.Length == 0)
             return "";
         var main = words[0];
-        if (main.StartsWith("tw:", StringComparison.OrdinalIgnoreCase))
-            main = "twitch:" + main[3..];
+        if (main.StartsWith("twitch:", StringComparison.OrdinalIgnoreCase))
+            main = "tw:" + main[7..];
         else if (IsNicoLiveId(main) || IsNicoVideoId(main) || IsNicoLiveVodId(main))
             main = "nico:" + main;
         else if (string.Equals(main, "pattern", StringComparison.OrdinalIgnoreCase))
@@ -510,13 +540,18 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     private static bool HasPrefix(string main, string prefix, Func<string, bool> rest) =>
         main.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && rest(main[prefix.Length..]);
 
-    /// <summary>twitch:&lt;channel&gt; (tw: for short): a Twitch live stream through streamlink.</summary>
+    /// <summary>tw:&lt;channel&gt; (twitch: is an alias): a Twitch live stream, as the embed or
+    /// through streamlink as the server is configured (<see cref="ScreenSourceDefaults"/>).</summary>
     public static bool IsTwitchSource(string? source) =>
-        source is not null && HasPrefix(MainOf(source), "twitch:", IsTwitchChannel);
+        source is not null && HasPrefix(MainOf(source), "tw:", IsTwitchChannel);
 
     /// <summary>twe:&lt;channel&gt;: the Twitch player embed in the off-screen browser.</summary>
     public static bool IsTwitchEmbedSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "twe:", IsTwitchChannel);
+
+    /// <summary>twl:&lt;channel&gt;: a Twitch live stream through streamlink.</summary>
+    public static bool IsTwitchStreamlinkSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "twl:", IsTwitchChannel);
 
     /// <summary>nico:lv… (a bare lv… id): a Nico Live programme through streamlink.</summary>
     public static bool IsNicoLiveSource(string? source) =>
@@ -531,9 +566,27 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     public static bool IsNicoVideoSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "nico:", IsNicoVideoId);
 
-    /// <summary>yt:&lt;id&gt;: a YouTube video through yt-dlp, with a shared timeline.</summary>
+    /// <summary>yt:&lt;id&gt;: a YouTube video with a shared timeline, as the embed or through
+    /// yt-dlp as the server is configured (<see cref="ScreenSourceDefaults"/>).</summary>
     public static bool IsYouTubeVideoSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "yt:", IsYouTubeId);
+
+    /// <summary>ytd:&lt;id&gt;: a YouTube video through yt-dlp, with a shared timeline.</summary>
+    public static bool IsYouTubeDlpSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "ytd:", IsYouTubeId);
+
+    /// <summary>
+    /// yte:&lt;id&gt;: a YouTube video as YouTube's own player embed, in the off-screen browser,
+    /// looping. The embed only plays inside a page (bare, YouTube refuses it), so it goes through
+    /// this server's own /ai-sp/yt-embed page, which the hook fetches from wherever it got the
+    /// screen page (the URL is root-relative). A video with a shared timeline like yt:, put into
+    /// that page's URL too, so the embed can seek to it and pause with it.
+    /// </summary>
+    public static bool IsYouTubeEmbedSource(string? source) =>
+        source is not null && HasPrefix(MainOf(source), "yte:", IsYouTubeId);
+
+    /// <summary>The root-relative page yte: expands to, before its query.</summary>
+    public const string YouTubeEmbedPage = "/ai-sp/yt-embed";
 
     /// <summary>ytl:&lt;id&gt;: a YouTube live stream through streamlink.</summary>
     public static bool IsYouTubeLiveSource(string? source) =>
@@ -554,9 +607,17 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     public static bool IsElectronSource(string? source) =>
         source is not null && HasPrefix(MainOf(source), "electron:", IsPageUrl);
 
-    /// <summary>Sources the off-screen browser shows: electron:&lt;url&gt; and the Twitch embed.</summary>
-    public static bool IsBrowserSource(string? source) =>
-        IsElectronSource(source) || IsTwitchEmbedSource(source);
+    /// <summary>Sources the off-screen browser shows: electron:&lt;url&gt;, the Twitch and YouTube
+    /// embeds, and tw:/yt: when the defaults send them to the embeds.</summary>
+    public static bool IsBrowserSource(string? source, ScreenSourceDefaults? defaults = null)
+    {
+        var d = defaults ?? ScreenSourceDefaults.Default;
+        return IsElectronSource(source)
+            || IsTwitchEmbedSource(source)
+            || IsYouTubeEmbedSource(source)
+            || (d.TwitchEmbed && IsTwitchSource(source))
+            || (d.YouTubeEmbed && IsYouTubeVideoSource(source));
+    }
 
     /// <summary>
     /// channel:&lt;n&gt;: indirects to whatever /channel assigned channel n (see
@@ -600,10 +661,12 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         && !IsVideoSource(source)
         && !IsChannelSource(source);
 
-    /// <summary>A video with a shared timeline (not a live stream): yt:, sm… and pattern:vod.
-    /// The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
+    /// <summary>A video with a shared timeline (not a live stream): yt:, yte:, ytd:, sm… and
+    /// pattern:vod. The hook seeks to the shared position and /screen pause, resume and seek move it.</summary>
     public static bool IsVideoSource(string? source) =>
         IsYouTubeVideoSource(source)
+        || IsYouTubeEmbedSource(source)
+        || IsYouTubeDlpSource(source)
         || IsNicoVideoSource(source)
         || IsNicoLiveVodSource(source)
         || (
@@ -618,6 +681,7 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     public static bool IsTypedSource(string? source) =>
         IsTwitchSource(source)
         || IsTwitchEmbedSource(source)
+        || IsTwitchStreamlinkSource(source)
         || IsNicoLiveSource(source)
         || IsYouTubeLiveSource(source)
         || IsVideoSource(source)
@@ -695,14 +759,22 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
     /// The form the launcher hook understands: streamlink:&lt;url&gt; (anything streamlink
     /// opens), stream:&lt;url&gt; (anything ffmpeg opens), yt-dlp:&lt;url&gt; (a video it seeks),
     /// pattern:live, pattern:vod and electron:&lt;http(s) url&gt;; the friendly ids are
-    /// vocabulary of this server. Page URLs and the page's own keywords pass through.
+    /// vocabulary of this server, and tw:/yt: go where `defaults` says (the server's
+    /// configuration; the built-in default is the embeds). Page URLs and the page's own keywords
+    /// pass through.
     /// </summary>
-    public static string ToHookSource(string source)
+    public static string ToHookSource(string source, ScreenSourceDefaults? defaults = null)
     {
+        var d = defaults ?? ScreenSourceDefaults.Default;
         var words = Normalize(source).Split(' ');
         var main = words[0];
+        // The short forms that leave the choice to the server go the way it is configured.
         if (IsTwitchSource(main))
-            main = "streamlink:https://twitch.tv/" + main[7..];
+            main = (d.TwitchEmbed ? "twe:" : "twl:") + main[3..];
+        else if (IsYouTubeVideoSource(main))
+            main = (d.YouTubeEmbed ? "yte:" : "ytd:") + main[3..];
+        if (IsTwitchStreamlinkSource(main))
+            main = "streamlink:https://twitch.tv/" + main[4..];
         else if (IsTwitchEmbedSource(main))
             main =
                 "electron:https://player.twitch.tv/?channel="
@@ -715,8 +787,10 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
             main = "streamlink:https://live.nicovideo.jp/watch/" + main[5..];
         else if (IsNicoVideoSource(main))
             main = "yt-dlp:https://www.nicovideo.jp/watch/" + main[5..];
-        else if (IsYouTubeVideoSource(main))
-            main = "yt-dlp:https://www.youtube.com/watch?v=" + main[3..];
+        else if (IsYouTubeDlpSource(main))
+            main = "yt-dlp:https://www.youtube.com/watch?v=" + main[4..];
+        else if (IsYouTubeEmbedSource(main))
+            main = "electron:" + YouTubeEmbedPage + "?v=" + main[4..];
         else if (IsYouTubeLiveSource(main))
             main = "streamlink:https://www.youtube.com/watch?v=" + main[4..];
         return string.Join(' ', new[] { main }.Concat(words.Skip(1)));
@@ -780,22 +854,22 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
                     RoomTvKey(mapId ?? 0, channel, movieId),
                     _ => new Timeline(_time.GetUtcNow(), 0, null)
                 );
-                return ToHookSource(typed) + " " + TimelineWords(timeline);
+                return WithTimeline(ToHookSource(typed, _defaults), timeline);
             }
             if (IsTypedSource(typed))
-                return ToHookSource(ResolveChannelIndirection(typed, requestTvId));
+                return ToHookSource(ResolveChannelIndirection(typed, requestTvId), _defaults);
         }
         var entry = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
         if (entry is null)
             return route == "room-tv"
                 ? Blank
-                : ToHookSource(ResolveChannelIndirection("channel:auto", requestTvId));
+                : ToHookSource(ResolveChannelIndirection("channel:auto", requestTvId), _defaults);
         if (string.Equals(entry.Source, TestScreen, StringComparison.OrdinalIgnoreCase))
             return null;
         var assigned = ResolveChannelIndirection(entry.Source, requestTvId);
         // Town screens attenuate with distance by default; an explicit rolloff word wins, filled
         // out to the hook's seven-number form; rolloff:flat drops it.
-        var words = ToHookSource(assigned).Split(' ').ToList();
+        var words = ToHookSource(assigned, _defaults).Split(' ').ToList();
         var rolloffIndex = words.FindIndex(IsRolloffWord);
         if (rolloffIndex >= 0)
         {
@@ -813,8 +887,33 @@ public sealed class ScreenAssignments(TimeProvider? time = null)
         {
             words.Add(defaultRolloff);
         }
-        if (IsVideoSource(assigned))
-            words.Add(TimelineWords(entry.Timeline));
-        return string.Join(' ', words);
+        var joined = string.Join(' ', words);
+        return IsVideoSource(assigned) ? WithTimeline(joined, entry.Timeline) : joined;
     }
+}
+
+/// <summary>
+/// Where the short ids that leave the choice to the server go: tw: to the Twitch embed (twe:)
+/// or streamlink (twl:), yt: to the YouTube embed (yte:) or yt-dlp (ytd:). The embeds are the
+/// built-in default: nothing to install on the viewer's side, and YouTube is friendlier to its
+/// own player than to yt-dlp. From the server's [Server:Screens] settings, whose values are the
+/// hook sources each becomes: electron, streamlink, yt-dlp.
+/// </summary>
+public sealed record ScreenSourceDefaults(bool TwitchEmbed = true, bool YouTubeEmbed = true)
+{
+    public static readonly ScreenSourceDefaults Default = new();
+
+    public static ScreenSourceDefaults FromOptions(ScreenOptions options) =>
+        new(
+            TwitchEmbed: !string.Equals(
+                options.Twitch,
+                "streamlink",
+                StringComparison.OrdinalIgnoreCase
+            ),
+            YouTubeEmbed: !string.Equals(
+                options.YouTube,
+                "yt-dlp",
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
 }

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -556,6 +556,22 @@ public sealed class ScreenAssignments(
     /// its edges cut off. The page computes the crop, knowing the box; a crop word given as
     /// well wins.
     /// </summary>
+    /// <summary>
+    /// run:&lt;url&gt;: a script the off-screen browser fetches and runs in an electron: page once
+    /// it has loaded (a site's own button, a layout switch), as an http(s) URL or a root-relative
+    /// path of this server's (/ai-sp/run/…), taken at the screen page's origin like the embed pages.
+    /// </summary>
+    public static bool IsRunWord(string? word) =>
+        word is not null
+        && word.StartsWith("run:", StringComparison.OrdinalIgnoreCase)
+        && word.Length > 4
+        && !word.Contains(';')
+        && (
+            word[4..].StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || word[4..].StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || (word[4] == '/' && (word.Length == 5 || word[5] != '/'))
+        );
+
     public static bool IsExtendWord(string? word) =>
         word is not null
         && word.StartsWith("extend:", StringComparison.OrdinalIgnoreCase)
@@ -814,6 +830,7 @@ public sealed class ScreenAssignments(
                     || IsPanWord(word)
                     || IsScrollWord(word)
                     || IsScaleWord(word)
+                    || IsRunWord(word)
                 )
         )
             return false;

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -286,7 +286,7 @@ public sealed class ScreenAssignments(
     /// Canonical form of a source: trimmed, with the typed short ids in their prefixed forms
     /// (twitch: to tw:, a bare lv… or sm… id to nico:, bare pattern to pattern:live). A
     /// source is "&lt;main&gt; [main:&lt;url&gt;] [banner:&lt;url&gt;] [&lt;url&gt;] [box:x/y/w/h]
-    /// [crop:sw/sh:cx/cy] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]] [fps:N]
+    /// [crop:sw/sh:cx/cy] [extend:l/t/r/b] [scrollx:N] [scrolly:N] [scroll:x/y] [scale:N] [key[:RRGGBB]] [fps:N]
     /// [rolloff:…] [pan]": main:&lt;url&gt; is a frame page under the main panel, with the box
     /// relative to that panel; banner:&lt;url&gt; is a page for the Stage banner strip (the
     /// title card when absent); a bare page URL is the raw form, a frame page under the whole
@@ -501,6 +501,19 @@ public sealed class ScreenAssignments(
         && size.All(part => int.TryParse(part, out var n) && n > 0)
         && halves[1].Split('/') is { Length: 2 } origin
         && origin.All(part => int.TryParse(part, out var n) && n >= 0);
+
+    /// <summary>
+    /// extend:left/top/right/bottom: the crop word worked out from the box the page shows the
+    /// source in: the picture is rendered that much larger on each side and the box shows the
+    /// window at left,top of it, so a browser page can be laid out wider than the panel and
+    /// its edges cut off. The page computes the crop, knowing the box; a crop word given as
+    /// well wins.
+    /// </summary>
+    public static bool IsExtendWord(string? word) =>
+        word is not null
+        && word.StartsWith("extend:", StringComparison.OrdinalIgnoreCase)
+        && word[7..].Split('/') is { Length: 4 } sides
+        && sides.All(part => int.TryParse(part, out var n) && n >= 0);
 
     private static string MainOf(string source) => Normalize(source).Split(' ')[0];
 
@@ -747,6 +760,7 @@ public sealed class ScreenAssignments(
                     || IsBannerWord(word)
                     || IsBoxWord(word)
                     || IsCropWord(word)
+                    || IsExtendWord(word)
                     || IsKeyWord(word)
                     || IsFpsWord(word)
                     || IsRolloffWord(word)

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -54,18 +54,30 @@ public sealed class ScreenAssignments(
     // channel map rather than fake furniture rows; channel:<n> is this server's vocabulary for
     // it, resolved below. tvid= is the client's own word for a channel number, unrelated to the
     // n: tag (see _byMovie).
-    private readonly ConcurrentDictionary<uint, string> _byChannel = new();
+    // A channel's video plays from the moment the channel was set, looping, for everyone
+    // who follows it (a room TV tuned to it, a map bound to it): the channel's own timeline,
+    // never paused or seeked (there is no /channel control; /screen's controls act on a map's
+    // own video, not on a channel it follows).
+    private readonly ConcurrentDictionary<uint, Entry> _byChannel = new();
 
     /// <summary>What channel &lt;n&gt; is currently assigned, or null if nothing is.</summary>
     public string? GetChannelSource(uint channel) =>
-        _byChannel.TryGetValue(channel, out var source) ? source : null;
+        _byChannel.TryGetValue(channel, out var entry) ? entry.Source : null;
+
+    /// <summary>The timeline channel &lt;n&gt;'s video runs on (from when it was set), or null.</summary>
+    public Timeline? GetChannelTimeline(uint channel) =>
+        _byChannel.TryGetValue(channel, out var entry) ? entry.Timeline : null;
 
     /// <summary>Clears channel &lt;n&gt;'s assignment; true if it had one.</summary>
     public bool ClearChannelSource(uint channel) => _byChannel.TryRemove(channel, out _);
 
-    /// <summary>Assigns channel &lt;n&gt; a source; see <see cref="IsValidChannelContentSource"/>.</summary>
+    /// <summary>Assigns channel &lt;n&gt; a source (see <see cref="IsValidChannelContentSource"/>);
+    /// a video starts from now, so setting it again restarts it.</summary>
     public void SetChannelSource(uint channel, string source) =>
-        _byChannel[channel] = Normalize(source);
+        _byChannel[channel] = new Entry(
+            Normalize(source),
+            new Timeline(_time.GetUtcNow(), 0, null)
+        );
 
     /// <summary>Every map currently bound to channel &lt;n&gt; via channel:&lt;n&gt; (see /channel).</summary>
     public IReadOnlyList<uint> GetMapsBoundToChannel(uint channel) =>
@@ -644,9 +656,9 @@ public sealed class ScreenAssignments(
         uint.Parse(MainOf(source).AsSpan(8), NumberStyles.None, CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// What /channel accepts for a channel's content: a bare stream or a web page, not a video
-    /// with a shared timeline (channels are livestream-only, with no per-channel
-    /// pause/resume/seek) and not another channel (no indirection chains). A channel is purely a
+    /// What /channel accepts for a channel's content: a bare stream, a web page or a video (which
+    /// loops on the channel's own timeline from when it was set: no per-channel
+    /// pause/resume/seek), not another channel (no indirection chains). A channel is purely a
     /// source map: no box, key, main:, crop: or other framing extras here; those belong on
     /// whoever references the channel (a room TV typing channel:&lt;n&gt;, or /screen
     /// channel:&lt;n&gt; box:... key main:...), since different screens frame the same channel
@@ -658,7 +670,6 @@ public sealed class ScreenAssignments(
         source is not null
         && !ExtrasOf(source).Any()
         && (IsStreamSource(source) || IsPageUrl(source))
-        && !IsVideoSource(source)
         && !IsChannelSource(source);
 
     /// <summary>A video with a shared timeline (not a live stream): yt:, yte:, ytd:, sm… and
@@ -808,14 +819,32 @@ public sealed class ScreenAssignments(
     /// that is unassigned also resolves to the title card, same as an unassigned room TV's
     /// channel button. Anything that is not a channel: word passes through untouched.
     /// </summary>
-    private string ResolveChannelIndirection(string source, uint? requestTvId)
+    private string ResolveChannelIndirection(
+        string source,
+        uint? requestTvId,
+        out Timeline? channelTimeline
+    )
     {
+        channelTimeline = null;
         var words = Normalize(source).Split(' ');
         if (!IsChannelSource(words[0]))
             return source;
         var n = IsAutoChannelWord(words[0]) ? requestTvId : ChannelNumberOf(words[0]);
         var content = n is { } number ? MainOf(GetChannelSource(number) ?? TitleCard) : TitleCard;
+        if (n is { } bound)
+            channelTimeline = GetChannelTimeline(bound);
         return string.Join(' ', new[] { content }.Concat(words.Skip(1)));
+    }
+
+    /// <summary>A channel reference resolved to the hook's form: a video on the channel runs on
+    /// the channel's timeline, shared by everyone following it.</summary>
+    private string ResolveChannelReference(string source, uint? requestTvId)
+    {
+        var resolved = ResolveChannelIndirection(source, requestTvId, out var channelTimeline);
+        var hook = ToHookSource(resolved, _defaults);
+        return channelTimeline is not null && IsVideoSource(resolved)
+            ? WithTimeline(hook, channelTimeline)
+            : hook;
     }
 
     /// <summary>
@@ -857,16 +886,20 @@ public sealed class ScreenAssignments(
                 return WithTimeline(ToHookSource(typed, _defaults), timeline);
             }
             if (IsTypedSource(typed))
-                return ToHookSource(ResolveChannelIndirection(typed, requestTvId), _defaults);
+                return ResolveChannelReference(typed, requestTvId);
         }
         var entry = mapId is { } map && _byMap.TryGetValue(map, out var found) ? found : null;
         if (entry is null)
             return route == "room-tv"
                 ? Blank
-                : ToHookSource(ResolveChannelIndirection("channel:auto", requestTvId), _defaults);
+                : ResolveChannelReference("channel:auto", requestTvId);
         if (string.Equals(entry.Source, TestScreen, StringComparison.OrdinalIgnoreCase))
             return null;
-        var assigned = ResolveChannelIndirection(entry.Source, requestTvId);
+        var assigned = ResolveChannelIndirection(
+            entry.Source,
+            requestTvId,
+            out var channelTimeline
+        );
         // Town screens attenuate with distance by default; an explicit rolloff word wins, filled
         // out to the hook's seven-number form; rolloff:flat drops it.
         var words = ToHookSource(assigned, _defaults).Split(' ').ToList();
@@ -888,7 +921,11 @@ public sealed class ScreenAssignments(
             words.Add(defaultRolloff);
         }
         var joined = string.Join(' ', words);
-        return IsVideoSource(assigned) ? WithTimeline(joined, entry.Timeline) : joined;
+        // A video of the map's own runs on the map's timeline (/screen pause, resume, seek); one
+        // followed through a channel on the channel's, the same for every screen following it.
+        return IsVideoSource(assigned)
+            ? WithTimeline(joined, channelTimeline ?? entry.Timeline)
+            : joined;
     }
 }
 

--- a/aisp.Common/Game/ScreenAssignments.cs
+++ b/aisp.Common/Game/ScreenAssignments.cs
@@ -275,12 +275,59 @@ public sealed class ScreenAssignments(
     public const string TwitchEmbedParent = "aisp.moe";
 
     /// <summary>
-    /// The map with the Nico Live billboard (seedData/maps.json: "Stage"). notify_nicolive_reload
-    /// only does anything there (confirmed on the shopping mall, which has none): the client has
-    /// nothing on other maps that reacts to it, so sending it elsewhere is a silent no-op.
-    /// CmdExecHandler scopes both its sends (/screen, /channel) to this map.
+    /// The map with the Nico Live billboard (seedData/maps.json: "Stage"), the one screen the
+    /// client itself reloads on notify_nicolive_reload (confirmed on the shopping mall, which
+    /// has none, that the client does nothing with it elsewhere). The launcher hook fills that
+    /// in for a town map's own screens, so CmdExecHandler sends the notify on every map.
     /// </summary>
     public const uint StageMapId = 19_001_003;
+
+    /// <summary>
+    /// The live id notify_nicolive_reload carries doubles as the reload's scope for the
+    /// launcher hook, which reloads a town map's own screens on that packet: lv0..lv99 means
+    /// only the screens whose own tvid= (the channel number the client gave them) is that
+    /// number, lv100 every screen on the map. The Stage's billboard re-navigates to the id as
+    /// a page, which the emulator ignores (live-watch serves the same page for any id).
+    /// </summary>
+    public const string ReloadEveryScreen = "lv100";
+
+    /// <summary>
+    /// lv200: every screen on the map, and the hook first tears down whatever it plays there
+    /// (the stream or browser source) before the page reloads, so a stuck decoder or a wedged
+    /// player goes with it. What /screen reload sends.
+    /// </summary>
+    public const string ReloadEveryScreenHard = "lv200";
+
+    /// <summary>The reload id for the screens following channel n (see <see cref="ReloadEveryScreen"/>); every screen past lv99.</summary>
+    public static string ReloadForChannel(uint channel) =>
+        channel <= 99
+            ? string.Create(CultureInfo.InvariantCulture, $"lv{channel}")
+            : ReloadEveryScreen;
+
+    /// <summary>
+    /// How a map's own screens relate to channel n: bound to it (/screen channel:n), following
+    /// whichever channel each screen's own tvid= names (no assignment, or channel:auto: the
+    /// screens on channel n among them are the ones that show it), or showing something else.
+    /// </summary>
+    public enum ChannelFollowing
+    {
+        None,
+        Bound,
+        Auto,
+    }
+
+    public ChannelFollowing FollowsChannel(uint mapId, uint channel)
+    {
+        var source = Get(mapId);
+        if (source is null)
+            return ChannelFollowing.Auto;
+        var main = MainOf(source);
+        if (!IsChannelSource(main))
+            return ChannelFollowing.None;
+        if (IsAutoChannelWord(main))
+            return ChannelFollowing.Auto;
+        return ChannelNumberOf(main) == channel ? ChannelFollowing.Bound : ChannelFollowing.None;
+    }
 
     /// <summary>
     /// Canonical form of a source: trimmed, with the typed short ids in their prefixed forms

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -933,7 +933,7 @@ public class CmdExecHandler(
     /// <summary>
     /// /screen &lt;source&gt; plays a source on every in-game screen of the map the player is on
     /// (the Akihabara display, the Stage billboard, TVs on a channel): the ids anyone may type
-    /// into a room TV (tw:, twe:, yt:, ytl:, lv…, lv…:vod, sm…, pattern:live, pattern:vod,
+    /// into a room TV (tw:, twe:, twl:, yt:, yte:, ytd:, ytl:, lv…, lv…:vod, sm…, pattern:live, pattern:vod,
     /// title), plus streamlink:&lt;url&gt; or stream:&lt;url&gt; for the launcher hook to decode,
     /// electron:&lt;http(s) url&gt; for an off-screen browser overlay, or an http(s) URL of a
     /// web page to show in IE. /screen off clears it; /screen alone shows it.
@@ -1002,8 +1002,8 @@ public class CmdExecHandler(
         {
             await SendSystemNoticeAsync(
                 session,
-                "/screen <source> [extras]. Sources: tw:<channel> (Twitch), twe:<channel> (Twitch embed), ytl:<id> (YouTube live), lv<id> (Nico Live),\n"
-                    + "yt:<id> (YouTube), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
+                "/screen <source> [extras]. Sources: tw:<channel> (Twitch, the embed or streamlink as the server is set), twe:<channel> (Twitch's embed), twl:<channel> (Twitch through streamlink), ytl:<id> (YouTube live through streamlink), lv<id> (Nico Live),\n"
+                    + "yt:<id> (YouTube, the embed or yt-dlp as the server is set), yte:<id> (YouTube's own embed, looping), ytd:<id> (YouTube through yt-dlp), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
                     + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1041,7 +1041,7 @@ public class CmdExecHandler(
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off. /screen reload (anyone) reloads your own client's screens here.\n"
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card; a frame page gets what plays through /ai-sp/aisp-frame.js),\n"
                     + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy, extend:l/t/r/b for the same worked out from the box (that much more on each side, the box showing the window at l,t),\n"
-                    + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
+                    + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch), run:<url> for a script to run in an electron: page once loaded,\n"
                     + "key[:RRGGBB] to colour-key it,\n"
                     + "fps:N (15/20/25/30/50/60), rolloff:near/far, rolloff:near/far/max/min (gains to fade between, default 1/0), rolloff:x/y/z/near/far, rolloff:x/y/z/near/far/max/min or rolloff:flat, pan to also stereo-pan by bearing.",
                 ct

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1034,8 +1034,8 @@ public class CmdExecHandler(
         {
             await SendSystemNoticeAsync(
                 session,
-                "/screen <source> [extras]. Sources: tw:<channel> (Twitch, the embed or streamlink as the server is set), twe:<channel> (Twitch's embed), twl:<channel> (Twitch through streamlink), ytl:<id> (YouTube live through streamlink), lv<id> (Nico Live),\n"
-                    + "yt:<id> (YouTube, the embed or yt-dlp as the server is set), yte:<id> (YouTube's own embed, looping), ytd:<id> (YouTube through yt-dlp), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
+                "/screen <source> [extras]. Sources: tw:<channel> (Twitch, the embed or streamlink as the server is set), twe:<channel> (Twitch's embed), twl:<channel> (Twitch through streamlink), ytl:<id> (YouTube live through streamlink), lv<id> (Nico Live, its watch page in the browser or streamlink as the server is set; nne:lv<id> / nnl:lv<id> to pick),\n"
+                    + "yt:<id> (YouTube, the embed or yt-dlp as the server is set), yte:<id> (YouTube's own embed, looping), ytd:<id> (YouTube through yt-dlp), sm<id> (Nico video, its watch page in the browser or yt-dlp as the server is set; nne:sm<id> / nnd:sm<id> to pick), lv<id>:vod (an archived Nico Live, once Nico has one, through yt-dlp) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
                     + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off. /screen reload (anyone) reloads your own client's screens here.\n"

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1039,7 +1039,7 @@ public class CmdExecHandler(
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
                     + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off. /screen reload (anyone) reloads your own client's screens here.\n"
-                    + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
+                    + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card; a frame page gets what plays through /ai-sp/aisp-frame.js),\n"
                     + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy, extend:l/t/r/b for the same worked out from the box (that much more on each side, the box showing the window at l,t),\n"
                     + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
                     + "key[:RRGGBB] to colour-key it,\n"

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1047,8 +1047,9 @@ public class CmdExecHandler(
     }
 
     /// <summary>
-    /// /channel &lt;n&gt; &lt;source&gt; assigns channel n's content (livestream only, since a
-    /// channel has no per-viewer pause/resume/seek) and pushes every room TV already tuned to it
+    /// /channel &lt;n&gt; &lt;source&gt; assigns channel n's content (a livestream, or a video,
+    /// which loops from the moment it is set on the channel's own timeline: there is no
+    /// pause/resume/seek for a channel) and pushes every room TV already tuned to it
     /// a fresh set-channel notify so it reloads at once, the way /screen reloads the live
     /// billboard. /channel &lt;n&gt; off clears it. Binding a map's own screens to a channel
     /// needs no separate command: /screen channel:n does it, channel:n being an ordinary source
@@ -1071,7 +1072,7 @@ public class CmdExecHandler(
         {
             await SendSystemNoticeAsync(
                 session,
-                "/channel <n> <source> sets what channel n shows (livestream only: tw:, twe:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL)"
+                "/channel <n> <source> sets what channel n shows (tw:, twe:, twl:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL, or a video: yt:, yte:, ytd:, sm…, lv…:vod, pattern:vod, looping from when it is set; no pause or seek)"
                     + " or off to clear it. To have a map's own screens follow a channel instead, use /screen channel:<n>.",
                 ct
             );
@@ -1088,7 +1089,7 @@ public class CmdExecHandler(
         {
             await SendSystemNoticeAsync(
                 session,
-                "/channel <n> <source>: a livestream only (tw:, twe:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL), or off to clear.",
+                "/channel <n> <source>: a livestream (tw:, twe:, twl:, ytl:, lv…, streamlink:<url>, stream:<url>, electron:<http(s) url>, pattern:live, a page URL) or a video (yt:, yte:, ytd:, sm…, lv…:vod, pattern:vod), without extras, or off to clear.",
                 ct
             );
             return;

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -1008,7 +1008,7 @@ public class CmdExecHandler(
                     + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
                     + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
-                    + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy,\n"
+                    + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy, extend:l/t/r/b for the same worked out from the box (that much more on each side, the box showing the window at l,t),\n"
                     + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
                     + "key[:RRGGBB] to colour-key it,\n"
                     + "fps:N (15/20/25/30/50/60), rolloff:near/far, rolloff:near/far/max/min (gains to fade between, default 1/0), rolloff:x/y/z/near/far, rolloff:x/y/z/near/far/max/min or rolloff:flat, pan to also stereo-pan by bearing.",

--- a/aisp.Common/Handlers/Msg/CmdExecHandler.cs
+++ b/aisp.Common/Handlers/Msg/CmdExecHandler.cs
@@ -10,7 +10,6 @@ using aisp.Network.Packets.Area;
 using aisp.Network.Packets.Msg;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Character = aisp.Common.DAL.Entities.Character;
 
 namespace aisp.Common.Handlers.Msg;
@@ -32,7 +31,6 @@ public class CmdExecHandler(
     IWordFilter wordFilter,
     ScreenAssignments screenAssignments,
     INicotvRepository nicotvRepository,
-    IOptions<ServerOptions> serverOptions,
     ILogger<CmdExecHandler> logger
 ) : IPacketHandler, IRequiresAuthenticatedSession
 {
@@ -937,11 +935,12 @@ public class CmdExecHandler(
     /// title), plus streamlink:&lt;url&gt; or stream:&lt;url&gt; for the launcher hook to decode,
     /// electron:&lt;http(s) url&gt; for an off-screen browser overlay, or an http(s) URL of a
     /// web page to show in IE. /screen off clears it; /screen alone shows it.
-    /// The Stage billboard (see ScreenAssignments.StageMapId) reloads at once through
-    /// notify_nicolive_reload, same as /channel does when it changes a channel the Stage is
-    /// bound to (see HandleChannelCommandAsync); any other screen (a town map's own, Akihabara
-    /// confirmed, or another map bound to a channel) has no such thing and only picks up a
-    /// change on its next poll.
+    /// Every client on the map gets notify_nicolive_reload so its open screens reload at once:
+    /// the Stage billboard (see ScreenAssignments.StageMapId) by the client itself, a town map's
+    /// own screens (Akihabara confirmed) by the launcher hook, which reloads their pages on that
+    /// packet (the client alone does nothing with it there). Its live id is the reload's scope
+    /// (see ScreenAssignments.ReloadEveryScreen): every screen here. /screen reload, for anyone,
+    /// sends the same packet to that player only.
     /// </summary>
     private async Task HandleScreenCommandAsync(
         IPlayerSession session,
@@ -949,9 +948,42 @@ public class CmdExecHandler(
         CancellationToken ct
     )
     {
+        // /screen reload: anyone, for their own client only. The same notify_nicolive_reload
+        // the assignment commands push, so the screens where the player is reload (the Stage's
+        // billboard by the client, a town map's own screens by the launcher hook), for a page or
+        // a stream that got stuck: the hard id, which also has the hook tear down whatever a
+        // screen was playing before its page reloads.
+        if (args.Count == 1 && args[0].Equals("reload", StringComparison.OrdinalIgnoreCase))
+        {
+            var own = ResolveAreaClient(session);
+            if (own is null)
+            {
+                await SendSystemNoticeAsync(
+                    session,
+                    "/screen reload needs you to be on a map.",
+                    ct
+                );
+                return;
+            }
+            await own.SendAsync(
+                PacketType.NotifyNicoliveReload,
+                new NotifyNicoliveReload(ScreenAssignments.ReloadEveryScreenHard).ToBytes(),
+                ct
+            );
+            await SendSystemNoticeAsync(
+                session,
+                $"Map {own.MapId}: your screens are reloading.",
+                ct
+            );
+            return;
+        }
         if (session.User is not { } actor || !actor.Role.CanKickOrBan())
         {
-            await SendSystemNoticeAsync(session, "/screen is for moderators.", ct);
+            await SendSystemNoticeAsync(
+                session,
+                "/screen is for moderators (/screen reload is for anyone).",
+                ct
+            );
             return;
         }
         var areaClient = ResolveAreaClient(session);
@@ -968,7 +1000,7 @@ public class CmdExecHandler(
                 session,
                 current is null
                     ? $"Map {mapId}: screens show the default page. /screen tw:<channel> | yt:<id> | stream:<url> | <page url> | title | off"
-                    : $"Map {mapId}: screens play {current}. /screen off to clear.",
+                    : $"Map {mapId}: screens play {current}. /screen off to clear, /screen reload to reload your own.",
                 ct
             );
             return;
@@ -1006,7 +1038,7 @@ public class CmdExecHandler(
                     + "yt:<id> (YouTube, the embed or yt-dlp as the server is set), yte:<id> (YouTube's own embed, looping), ytd:<id> (YouTube through yt-dlp), sm<id> (Nico video), lv<id>:vod (an archived Nico Live, once Nico has one) or pattern:vod (videos, played in step by everyone; then /screen pause, resume, seek <seconds>),\n"
                     + "pattern:live (the hook's own test picture and tone), streamlink:<url>, stream:<url>, electron:<http(s) url> (off-screen browser), a web page URL,\n"
                     + "channel:<n> (follows whatever /channel <n> <source> is showing), channel:auto (follows this screen's own tvid=, if it has one; the title card without one),\n"
-                    + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off.\n"
+                    + "blank, title, testscreen, calibrate, c:x1/y1:x2/y2:..., or off. /screen reload (anyone) reloads your own client's screens here.\n"
                     + "Extras: main:<url> (a frame page under the main panel; box:x/y/w/h is then relative to it), banner:<url> (the Stage banner strip, else the title card),\n"
                     + "box:x/y/w/h to place the video inside the crop, crop:sw/sh:cx/cy to render it at sw x sh and show the box-sized window at cx,cy, extend:l/t/r/b for the same worked out from the box (that much more on each side, the box showing the window at l,t),\n"
                     + "scrollx:N scrolly:N or scroll:x/y to pan an electron: document, scale:N for browser zoom (1=100%; not a texture stretch),\n"
@@ -1023,25 +1055,22 @@ public class CmdExecHandler(
             clearing ? "(default)" : source
         );
 
-        // The Nico Live billboard re-navigates on this notify; the page it fetches carries the
-        // new source. Confirmed by testing to do nothing on a map without one (the shopping
-        // mall), so only bother sending it on the one map that has it.
-        var liveId = serverOptions.Value.NicoLive.LiveId?.Trim() ?? "";
+        // Every client on the map: the Nico Live billboard (the Stage) re-navigates on this
+        // notify by itself, and the launcher hook reloads a town map's own screens on it (the
+        // client alone does nothing with it there, confirmed on the shopping mall). The page
+        // each fetches carries the new source.
         var reloaded = 0;
-        if (!string.IsNullOrEmpty(liveId) && mapId == ScreenAssignments.StageMapId)
+        var reload = new NotifyNicoliveReload(ScreenAssignments.ReloadEveryScreen).ToBytes();
+        foreach (var client in state.AreaClients.Where(c => c.MapId == mapId))
         {
-            var reload = new NotifyNicoliveReload(liveId).ToBytes();
-            foreach (var client in state.AreaClients.Where(c => c.MapId == mapId))
-            {
-                await client.SendAsync(PacketType.NotifyNicoliveReload, reload, ct);
-                reloaded++;
-            }
+            await client.SendAsync(PacketType.NotifyNicoliveReload, reload, ct);
+            reloaded++;
         }
         await SendSystemNoticeAsync(
             session,
             clearing
-                ? $"Map {mapId}: screens back to the default page ({reloaded} client(s) told); open screens follow within a few seconds."
-                : $"Map {mapId}: screens set to {source} ({reloaded} client(s) told); open screens follow within a few seconds.",
+                ? $"Map {mapId}: screens back to the default page ({reloaded} client(s) told)."
+                : $"Map {mapId}: screens set to {source} ({reloaded} client(s) told).",
             ct
         );
     }
@@ -1053,9 +1082,12 @@ public class CmdExecHandler(
     /// a fresh set-channel notify so it reloads at once, the way /screen reloads the live
     /// billboard. /channel &lt;n&gt; off clears it. Binding a map's own screens to a channel
     /// needs no separate command: /screen channel:n does it, channel:n being an ordinary source
-    /// like tw: or yt:. Bound map screens other than the Stage have no reload packet of their own
-    /// (nothing else in the protocol does this) and only pick a content change up on their next
-    /// poll, same as any other /screen change.
+    /// like tw: or yt:. Map screens get the same notify_nicolive_reload /screen sends (the
+    /// Stage's billboard and, through the launcher hook, a town map's own screens reload on
+    /// it): every client on a bound map, with the id that reloads every screen, and every
+    /// client on a map whose screens follow their own channel number (no assignment, or
+    /// channel:auto), with the id that reloads only the screens on this channel (see
+    /// ScreenAssignments.ReloadForChannel); the server need not know which screens a map has.
     /// </summary>
     private async Task HandleChannelCommandAsync(
         IPlayerSession session,
@@ -1127,31 +1159,37 @@ public class CmdExecHandler(
             roomsNotified++;
         }
 
-        // A map bound to this channel via /screen channel:<n> gets the same reload /screen itself
-        // sends, and just as scoped: only the Stage's own screen reacts to this notify (see
-        // ScreenAssignments.StageMapId), so a bound town screen only picks this up on its next
-        // poll.
-        var liveId = serverOptions.Value.NicoLive.LiveId?.Trim() ?? "";
-        var boundMaps = screenAssignments.GetMapsBoundToChannel(channelNumber);
-        var mapsNotified = 0;
-        if (!string.IsNullOrEmpty(liveId) && boundMaps.Contains(ScreenAssignments.StageMapId))
+        // Map screens, through the same reload /screen itself sends (the Stage's billboard
+        // reloads by itself, a town map's own screens through the launcher hook): every client
+        // on a map bound to this channel reloads every screen there; every client on a map
+        // whose screens follow their own channel number reloads only those on this channel,
+        // the hook telling them apart by their tvid=. Rooms have their TVs told above.
+        var reloadAll = new NotifyNicoliveReload(ScreenAssignments.ReloadEveryScreen).ToBytes();
+        var reloadChannel = new NotifyNicoliveReload(
+            ScreenAssignments.ReloadForChannel(channelNumber)
+        ).ToBytes();
+        var mapsNotified = new HashSet<uint>();
+        var clientsNotified = 0;
+        foreach (var client in state.AreaClients)
         {
-            var recipients = state
-                .AreaClients.Where(c => c.MapId == ScreenAssignments.StageMapId)
-                .ToList();
-            if (recipients.Count > 0)
-            {
-                var reload = new NotifyNicoliveReload(liveId).ToBytes();
-                foreach (var client in recipients)
-                    await client.SendAsync(PacketType.NotifyNicoliveReload, reload, ct);
-                mapsNotified = 1;
-            }
+            if (MyRoomInfo.IsMyRoomMap(client.MapId))
+                continue;
+            var following = screenAssignments.FollowsChannel(client.MapId, channelNumber);
+            if (following == ScreenAssignments.ChannelFollowing.None)
+                continue;
+            await client.SendAsync(
+                PacketType.NotifyNicoliveReload,
+                following == ScreenAssignments.ChannelFollowing.Bound ? reloadAll : reloadChannel,
+                ct
+            );
+            mapsNotified.Add(client.MapId);
+            clientsNotified++;
         }
         await SendSystemNoticeAsync(
             session,
             clearing
-                ? $"Channel {channelNumber}: cleared ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {mapsNotified} of {boundMaps.Count} map screen(s) told, the rest follow within a few seconds)."
-                : $"Channel {channelNumber}: set to {source} ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {mapsNotified} of {boundMaps.Count} map screen(s) told, the rest follow within a few seconds).",
+                ? $"Channel {channelNumber}: cleared ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {clientsNotified} client(s) on {mapsNotified.Count} map(s) told)."
+                : $"Channel {channelNumber}: set to {source} ({tuned.Count} TV(s) in {roomsNotified} room(s) told; {clientsNotified} client(s) on {mapsNotified.Count} map(s) told).",
             ct
         );
     }

--- a/aisp.Server/Program.cs
+++ b/aisp.Server/Program.cs
@@ -145,7 +145,12 @@ internal class Program
         builder
             .Services.AddOptions<ApiSettings>()
             .Bind(builder.Configuration.GetSection("ApiSettings"));
-        builder.Services.AddSingleton<ScreenAssignments>();
+        builder.Services.AddSingleton(sp => new ScreenAssignments(
+            TimeProvider.System,
+            ScreenSourceDefaults.FromOptions(
+                sp.GetRequiredService<IOptions<ServerOptions>>().Value.Screens
+            )
+        ));
         builder.Services.AddSingleton<BroadcastService>();
         builder.Services.AddScoped<ModerationService>();
         builder.Services.AddScoped<UserAdminService>();

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -18,6 +18,7 @@ namespace aisp.Server;
 ///   /ai-sp/live-watch?liveid=...          the Nico Live billboard
 ///   /ai-sp/screen?url=...                 anything else the client asked aisp.jp for
 ///   /ai-sp/screen-source?route=..&map=..  JSON {src} the page polls for changes
+///   /ai-sp/yt-embed?v=..                   YouTube's player embed in a page (the yte: source)
 /// All of them serve the same page: it shows which route and parameters it got, implements the
 /// script contract the client drives (external_nico_0.ext_*), and publishes volume, mute and the
 /// source to play in its title for the hook. The source is decided here from ScreenAssignments.
@@ -89,6 +90,22 @@ internal static class ScreenEndpointsExtensions
                             ?? "",
                     }
                 );
+            }
+        );
+        // The page around YouTube's player embed for the yte: source, fetched by the hook's
+        // off-screen browser; the id is checked, the rest of the query is the page's own.
+        app.MapGet(
+            ScreenAssignments.YouTubeEmbedPage,
+            async (HttpContext context, IWebHostEnvironment environment) =>
+            {
+                if (!ScreenAssignments.IsYouTubeId(context.Request.Query["v"]))
+                    return Results.BadRequest("v: a YouTube video id");
+                var file = environment.WebRootFileProvider.GetFileInfo("screen/yt-embed.html");
+                if (!file.Exists || file.PhysicalPath is null)
+                    return Results.NotFound();
+                var html = await File.ReadAllTextAsync(file.PhysicalPath, context.RequestAborted);
+                context.Response.Headers.CacheControl = "no-store";
+                return Results.Content(html, "text/html; charset=utf-8");
             }
         );
         // Polled by the page so a changed assignment reaches screens that are already open.

--- a/aisp.Server/ScreenEndpointsExtensions.cs
+++ b/aisp.Server/ScreenEndpointsExtensions.cs
@@ -242,8 +242,9 @@ internal static class ScreenEndpointsExtensions
         // one by a MyRoom map above) never needs the page to poll: the client re-navigates it on
         // every assignment change (movie set, channel switch, room re-entry). live-watch (the
         // Stage) is pushed too: both /screen and /channel on a map it is bound to send it
-        // notify_nicolive_reload (CmdExecHandler). A /channel-screen that did not resolve to a
-        // room TV is a town screen (confirmed on Akihabara) with neither guarantee, so it alone
+        // notify_nicolive_reload (CmdExecHandler), and so is a /channel-screen that did not
+        // resolve to a room TV, a town screen (confirmed on Akihabara): the launcher hook reloads
+        // its page on that same notify. Only the catch-all /screen page, which nothing pushes,
         // keeps polling. roomtv is a separate, narrower flag: only a genuine room TV shows the
         // comment overlay, never the Stage or a town screen, no matter what the page is told by
         // ext_setCommentVisible; the page cannot tell a room TV from anything else on its own,
@@ -251,7 +252,7 @@ internal static class ScreenEndpointsExtensions
         // (off when absent): the client never sets it, so the page must start from the server's
         // value, and it starts over on every re-navigation.
         var isRoomTv = effectiveRoute == "room-tv";
-        var noPoll = isRoomTv || effectiveRoute == "live-watch";
+        var noPoll = effectiveRoute != "screen";
         var titleSuffix =
             (isRoomTv ? ";roomtv=1" : "")
             + (noPoll ? ";nopoll=1" : "")

--- a/aisp.Server/appsettings.json
+++ b/aisp.Server/appsettings.json
@@ -23,7 +23,9 @@
         },
         "Screens": {
             "Twitch": "electron",
-            "YouTube": "electron"
+            "YouTube": "electron",
+            "NicoVideo": "electron",
+            "NicoLive": "electron"
         },
         "PacketChannelCapacity": 512,
         "MaxConcurrentClients": 32,

--- a/aisp.Server/appsettings.json
+++ b/aisp.Server/appsettings.json
@@ -21,6 +21,10 @@
         "NicoLive": {
             "LiveId": "lv1"
         },
+        "Screens": {
+            "Twitch": "electron",
+            "YouTube": "electron"
+        },
         "PacketChannelCapacity": 512,
         "MaxConcurrentClients": 32,
         "MaxReceiveFrameSize": 4096,

--- a/aisp.Server/wwwroot/ai-sp/aisp-frame.js
+++ b/aisp.Server/wwwroot/ai-sp/aisp-frame.js
@@ -1,0 +1,34 @@
+// For a page shown inside an in-game screen page as its main: or banner: frame: the same view
+// of what the screen plays that the screen page itself gets from the launcher hook. Include it
+// (<script src="/ai-sp/aisp-frame.js"></script>, or the absolute URL on the emulator's host)
+// and use any of:
+//   window.aisp            the latest media state: source, kind, url, title, duration,
+//                          position, elapsed, playing, paused, active, status, fps, box, crop
+//                          (null until the screen has something to say)
+//   window.onAisp(media)   called on every update, like in the screen page
+//   document 'aisp' event  detail = { media, screen }
+//   window.aispFrame       .media, .screen ({ route, kind, params, src, main, banner }) and
+//                          .on(fn), which also calls fn at once if state is already known
+// The screen page relays its state with postMessage on every change, when this frame loads,
+// and once more on request; a page loaded on its own (not in a frame) just never hears any.
+(function(){
+  var state={ media:null, screen:null }, listeners=[];
+  function tell(){
+    for(var i=0;i<listeners.length;i++){ try{ listeners[i](state); }catch(e){} }
+    if(typeof window.onAisp==='function'){ try{ window.onAisp(state.media); }catch(e){} }
+    try{ document.dispatchEvent(new CustomEvent('aisp',{detail:state})); }catch(e){}
+  }
+  window.aispFrame={
+    get media(){ return state.media; },
+    get screen(){ return state.screen; },
+    on:function(fn){ listeners.push(fn); if(state.screen){ try{ fn(state); }catch(e){} } return fn; }
+  };
+  window.addEventListener('message',function(e){
+    var d=e.data;
+    if(!d||d.type!=='aisp') return;
+    state.media=d.media||null; state.screen=d.screen||null;
+    window.aisp=state.media;
+    tell();
+  });
+  try{ if(window.parent&&window.parent!==window) window.parent.postMessage({type:'aisp:get'},'*'); }catch(e){}
+})();

--- a/aisp.Server/wwwroot/ai-sp/run/nicolive-player.js
+++ b/aisp.Server/wwwroot/ai-sp/run/nicolive-player.js
@@ -1,0 +1,45 @@
+// Run by the launcher hook's off-screen browser in a Nico Live watch page
+// (https://live.nicovideo.jp/watch/lv…), the nne:lv… source: the page cannot be framed
+// (X-Frame-Options), so it is loaded whole and this presses the stream player's own
+// フルスクリーン button, a page-level layout (the button's label flips to フルスクリーン解除, no
+// Fullscreen API) that scales the player to the viewport; the viewport is the video box, so the
+// box shows the stream alone. The player's header and its footer (controls, the comment form)
+// stay laid over the video, since nothing ever moves a mouse here, so they are hidden; Nico's
+// own flying comments stay. Anything else that plays on the page (the ad player at the top)
+// is muted and paused so only the stream is heard. The page renders late, so this keeps
+// looking for a while, and again after a layout change.
+(function(){
+  if(window.__aispNicoLive) return;
+  window.__aispNicoLive=true;
+  var style=document.createElement('style');
+  style.textContent='[class*="player-display-header"],[class*="player-display-footer-area"]{display:none!important}';
+  (document.head||document.documentElement).appendChild(style);
+  function streamVideo(){
+    var playing=[].slice.call(document.querySelectorAll('video')).filter(function(v){ return v.currentSrc&&!v.paused; });
+    // The stream player is the largest playing one; the ad is a small one near the top.
+    playing.sort(function(a,b){ var ra=a.getBoundingClientRect(), rb=b.getBoundingClientRect(); return rb.width*rb.height-ra.width*ra.height; });
+    return playing[0]||null;
+  }
+  function quietOthers(keep){
+    [].slice.call(document.querySelectorAll('video')).forEach(function(v){
+      if(v===keep) return;
+      try{ v.muted=true; v.pause(); }catch(e){}
+    });
+  }
+  function fullscreenButton(){
+    var all=[].slice.call(document.querySelectorAll('button'));
+    for(var i=0;i<all.length;i++){ var l=all[i].getAttribute('aria-label')||''; if(/フルスクリーン/.test(l)) return all[i]; }
+    return null;
+  }
+  var tries=0;
+  function step(){
+    tries++;
+    var v=streamVideo();
+    if(v) quietOthers(v);
+    var b=fullscreenButton();
+    var full=!!b&&/解除/.test(b.getAttribute('aria-label')||'');
+    if(b&&!full){ try{ b.click(); }catch(e){} }
+    if(tries<90) setTimeout(step, full?2000:500);
+  }
+  step();
+})();

--- a/aisp.Server/wwwroot/ai-sp/run/nicovideo-player.js
+++ b/aisp.Server/wwwroot/ai-sp/run/nicovideo-player.js
@@ -1,0 +1,153 @@
+// Run by the launcher hook's off-screen browser in a Nico video watch page
+// (https://www.nicovideo.jp/watch/sm…#start=<unix>&offset=<s>[&paused=<unix>]), the nne:sm…
+// source. The page's own player stays in charge (moving its elements out from under it left
+// its state, and so the comment renderer, stuck): this presses its 全画面表示 button, which
+// puts the player over the viewport (the video box), hides every sibling on the way from the
+// video up to that fullscreen box that holds neither the video nor a comment canvas (the top
+// banner, the controls, the comment form), and then steers the video element: volume up, the
+// shared timeline's position (the fragment, ignored by the site; modulo the length, within
+// kEdgeSeconds of either end from 0, the hook's ffmpeg rule) once the player itself has
+// started it, loop so it never reaches the end screen or the next video, pause for a paused
+// timeline. A pre-roll ad runs first: where it is a video of the page's own it is muted, hidden
+// and wound to its end at once (its skip button pressed as a fallback), and the player starts
+// the feature the moment it is done. The comments come in the site's language, which follows
+// the browser's Accept-Language unless the lang cookie says otherwise: without lang=ja-jp the
+// page loads the sparse en-us thread and no easy comments, so the cookie is set once (the
+// browser host's profile keeps it) and the page reloaded that one time. The title loses the
+// site's suffix. The page renders late, so this keeps checking for a while.
+(function(){
+  if(window.__aispNicoVideo) return;
+  window.__aispNicoVideo=true;
+  if(!/(^|;\s*)lang=ja-jp(;|$)/.test(document.cookie||'')){
+    document.cookie='lang=ja-jp; domain=.nicovideo.jp; path=/; max-age=31536000; secure; samesite=none';
+    if(/(^|;\s*)lang=ja-jp(;|$)/.test(document.cookie||'')){ location.reload(); return; }
+  }
+  var kEdgeSeconds=3;
+  var q={}, hash=(location.hash||'').replace(/^#/,'').split('&');
+  for(var i=0;i<hash.length;i++){ var kv=hash[i].split('='); if(kv[0]) q[decodeURIComponent(kv[0])]=decodeURIComponent(kv[1]||''); }
+  var start=+q.start||0, offset=+q.offset||0, paused=+q.paused||0;
+  function target(){ var until=paused?paused:Math.floor(new Date().getTime()/1000); return offset+Math.max(0,until-start); }
+  function startPosition(d){ if(!start||!(d>0)) return 0; var pos=target()%d; return (pos<kEdgeSeconds||pos>d-kEdgeSeconds)?0:pos; }
+  var style=document.createElement('style');
+  style.textContent=[
+    'html,body{overflow:hidden!important;background:#000!important}',
+    '.__aisp-hide{display:none!important}',
+    // Ads: their video, and whatever is laid over the picture in a frame.
+    'video.__aisp-ad,:fullscreen iframe{display:none!important}'
+  ].join('');
+  (document.head||document.documentElement).appendChild(style);
+  var main=null, seeked=false, seekedFor=0, tries=0, wrapped=0;
+  var wound=[]; // ad elements already wound to their end
+  var ownUrl=location.href, ownPath=location.pathname;
+  window.aispPlayer={mode:null, position:null, seeks:0, fullscreen:false, hidden:0, skips:0, playerStarted:false};
+  function buttonWith(re){ var all=[].slice.call(document.querySelectorAll('button')); for(var i=0;i<all.length;i++){ if(re.test(all[i].getAttribute('aria-label')||'')) return all[i]; } return null; }
+  function pick(){
+    var vids=[].slice.call(document.querySelectorAll('video')).filter(function(v){ return v.currentSrc&&v.duration>60; });
+    vids.sort(function(a,b){ return (b.duration||0)-(a.duration||0); });
+    return vids[0]||null;
+  }
+  // The chrome: on the way from the video up to the fullscreen box, every sibling that holds
+  // neither the video nor a canvas goes; the rest (the comment layers) stays where it is.
+  function hideChrome(fs){
+    var n=0, e=main;
+    while(e&&e!==fs&&e.parentElement){
+      var kids=[].slice.call(e.parentElement.children);
+      for(var i=0;i<kids.length;i++){
+        var k=kids[i];
+        if(k===e||k.contains(main)||k.querySelector('canvas')||k.tagName==='CANVAS') continue;
+        if(!k.classList.contains('__aisp-hide')){ k.classList.add('__aisp-hide'); n++; }
+      }
+      e=e.parentElement;
+    }
+    // The "貢献しませんか" bar over the picture is not a sibling on that chain: found by its
+    // text, hidden with the largest ancestor that holds neither the video nor a canvas.
+    var links=[].slice.call(document.querySelectorAll('a,span')).filter(function(a){ return a.children.length<=1&&/貢献しませんか/.test(a.textContent||''); });
+    for(var j=0;j<links.length;j++){
+      var t=links[j], top=t;
+      while(top.parentElement&&top.parentElement!==fs&&!top.parentElement.contains(main)&&!top.parentElement.querySelector('canvas')) top=top.parentElement;
+      if(!top.classList.contains('__aisp-hide')){ top.classList.add('__aisp-hide'); n++; }
+    }
+    window.aispPlayer.hidden+=n;
+  }
+  // The player's own continuous play moves on at the end (loop only spares the element's
+  // ended event, not the player's clock, which does not follow an element seek backwards
+  // while playing): just short of the end, press the player's own "0" key, a seek to the start
+  // that its clock and comments follow. On the element's events, since timers on this page run
+  // late; the shared timeline never lands in the last three seconds anyway.
+  function wrapToStart(){
+    if(Date.now()-wrapped<5000) return;
+    wrapped=Date.now();
+    try{
+      var opts={key:'0',code:'Digit0',keyCode:48,which:48,bubbles:true,cancelable:true};
+      document.body.dispatchEvent(new KeyboardEvent('keydown',opts));
+      document.body.dispatchEvent(new KeyboardEvent('keyup',opts));
+      window.aispPlayer.wraps=(window.aispPlayer.wraps||0)+1;
+    }catch(e){}
+  }
+  function watchEnd(v){
+    if(v.__aispWatched) return;
+    v.__aispWatched=true;
+    v.addEventListener('timeupdate',function(){ if(v===main&&v.duration>60&&v.currentTime>v.duration-1.5) wrapToStart(); });
+    v.addEventListener('ended',function(){ if(v===main&&v.duration>60){ wrapToStart(); try{ var p=v.play(); if(p&&p.catch) p.catch(function(){}); }catch(e){} } });
+  }
+  function skipAd(){
+    var all=[].slice.call(document.querySelectorAll('button'));
+    for(var i=0;i<all.length;i++){ var l=all[i].textContent||all[i].getAttribute('aria-label')||''; if(/スキップ/.test(l)&&!/秒後/.test(l)){ try{ all[i].click(); window.aispPlayer.skips++; }catch(e){} return; } }
+  }
+  function step(){
+    tries++;
+    var v=pick();
+    if(v&&v!==main){ main=v; seeked=false; watchEnd(main); }
+    // Every other video is an ad: muted, hidden once its short length is known, and wound to
+    // its last moment so the player takes it as watched.
+    var adPlaying=false;
+    [].slice.call(document.querySelectorAll('video')).forEach(function(o){
+      if(o===main){ o.classList.remove('__aisp-ad'); return; }
+      try{ o.muted=true; }catch(e){}
+      if(o.currentSrc&&o.duration>0&&o.duration<=60){
+        o.classList.add('__aisp-ad');
+        // Once loaded: started if the player left it waiting (the feature waits on it), and
+        // wound to its last moment, once; a re-seek of a stalled ad only stalls it more.
+        if(o.readyState>=2){
+          if(o.paused&&!o.ended){ try{ var ap=o.play(); if(ap&&ap.catch) ap.catch(function(){}); }catch(e){} }
+          if(wound.indexOf(o)<0&&!o.ended&&o.duration-o.currentTime>0.5){ wound.push(o); try{ o.currentTime=o.duration-0.1; window.aispPlayer.adsWound=(window.aispPlayer.adsWound||0)+1; }catch(e){} }
+        }
+        if(!o.paused&&!o.ended) adPlaying=true;
+      }
+    });
+    skipAd();
+    if(!document.fullscreenElement){ var fb=buttonWith(/^全画面表示する$/); if(fb) try{ fb.click(); }catch(e){} }
+    window.aispPlayer.fullscreen=!!document.fullscreenElement;
+    if(main&&document.fullscreenElement&&document.fullscreenElement.contains(main)) hideChrome(document.fullscreenElement);
+    if(main){
+      try{ main.loop=true; main.volume=1; main.muted=false; }catch(e){}
+      // The player may run the pre-roll through this same element: while its length is the
+      // ad's, the position and the wrap below must wait for the feature's.
+      var featureNow=main.duration>60;
+      window.aispPlayer.steps=tries;
+      if(wrapped&&Date.now()-wrapped<12000&&main.paused&&!paused){ var rb=buttonWith(/^再生する$/); if(rb) try{ rb.click(); }catch(e){} else try{ var pw=main.play(); if(pw&&pw.catch) pw.catch(function(){}); }catch(e){} }
+      // The player starts the feature itself once the ad is over; until it has, the element is
+      // left alone so the player's own state (and the comments with it) stays in step.
+      if(!main.paused) window.aispPlayer.playerStarted=true;
+      var started=window.aispPlayer.playerStarted;
+      // Seek once the player runs the feature; again should the element's length change under
+      // it (the same element, another media).
+      if(started&&featureNow&&(!seeked||Math.abs(seekedFor-main.duration)>1)&&main.readyState>=1){
+        seeked=true; seekedFor=main.duration;
+        var pos=startPosition(main.duration);
+        window.aispPlayer.mode=pos>0?'seek':'play'; window.aispPlayer.position=pos; window.aispPlayer.seeks++;
+        if(pos>0) try{ main.currentTime=pos; }catch(e){}
+      }
+      if(started&&seeked&&paused){ if(!main.paused){ var pb=buttonWith(/^一時停止する$/); if(pb) try{ pb.click(); }catch(e){} else try{ main.pause(); }catch(e){} } }
+      else if(!adPlaying&&main.paused&&main.readyState>=2&&tries>10){ var b=buttonWith(/^再生する$/); if(b) try{ b.click(); }catch(e){} else try{ var p=main.play(); if(p&&p.catch) p.catch(function(){}); }catch(e){} }
+    }
+    var t=document.title||'';
+    if(/ - ニコニコ動画$/.test(t)) document.title=t.replace(/ - ニコニコ動画$/,'');
+    // Should the page have moved to another video regardless (a navigation inside the page,
+    // which the host does not see), come back to this one, timeline and all.
+    if(location.pathname!==ownPath){ window.aispPlayer.strayed=(window.aispPlayer.strayed||0)+1; location.replace(ownUrl); return; }
+    // For the life of the page: the player may rebuild its elements at any time.
+    setTimeout(step, main&&seeked?(main.duration-main.currentTime<3?200:2000):500);
+  }
+  step();
+})();

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -121,10 +121,11 @@ body.tv #comments{top:36px}
   // Also gates the comment overlay below, so it can never show on anything but a room TV, no
   // matter what ext_setCommentVisible is called with.
   var roomTv=/;roomtv=1(?:;|$)/.test(document.title||'');
-  // Separately, whether this page needs to poll at all: true for a room TV (above), and also for
-  // live-watch (the Stage), which /screen and /channel both push a reload to instead. A town
-  // screen (a channel-screen that did not resolve to a room TV, Akihabara confirmed) has neither
-  // guarantee, so it is the one case still left polling.
+  // Separately, whether this page needs to poll at all: not for a room TV (above), nor for
+  // live-watch (the Stage) or a town screen (a channel-screen that did not resolve to a room
+  // TV, Akihabara confirmed), which /screen and /channel both push a reload to instead (the
+  // client reloads the Stage's billboard itself, the launcher hook a town screen's page). Only
+  // the catch-all screen page, which nothing pushes, is left polling.
   var noPoll=/;nopoll=1(?:;|$)/.test(document.title||'');
   // The comment overlay starts from the server's default for this TV (comment=1 in the title,
   // otherwise off). The client never sets it on its own: its panel button is an empty case in
@@ -525,9 +526,10 @@ body.tv #comments{top:36px}
   // (above) says the server already pushes this page a reload instead: a room TV re-navigates on
   // every assignment change on its own (movie set, channel switch, room re-entry), and live-watch
   // (the Stage) gets notify_nicolive_reload from both /screen and /channel. A /channel-screen
-  // that is not a room TV (a town map's own screen, Akihabara confirmed) has neither guarantee,
-  // so it is the one case polling; the pushed cases never run this at all, so a relaxed 30s
-  // interval here only affects that one less time-sensitive case.
+  // that is not a room TV (a town map's own screen, Akihabara confirmed) is reloaded on that
+  // notify by the launcher hook. Only the catch-all screen page (any other URL the client asked
+  // for) polls; the pushed cases never run this at all, so a relaxed 30s interval here only
+  // affects that one less time-sensitive case.
   function pollSource(){
     try{
       var xhr=new XMLHttpRequest();

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -44,7 +44,7 @@ body.tv #comments{top:36px}
 .ret{position:absolute;left:520px;font-size:12px;color:#00f}
 .corner{position:absolute;width:12px;height:12px;background:#f80}
 .panel{position:absolute;outline:2px solid #f80}
-.panel .lab{position:absolute;left:4px;top:2px;font-size:11px;color:#f80}
+.panel .lab{position:absolute;right:16px;bottom:2px;font-size:11px;color:#f80}
 .card{position:absolute;background:#0d0b1a;color:#e8e6f0;text-align:center;font-family:Verdana,Arial,sans-serif;font-weight:bold;overflow:hidden}
 .card .w{position:absolute;left:0;width:100%;letter-spacing:4px}
 .card .k{position:absolute;right:10px;top:0;height:100%;display:flex;align-items:center;font:bold 16px/20px "MS Gothic","ＭＳ ゴシック",monospace;letter-spacing:0;color:#e8e6f0}
@@ -85,13 +85,19 @@ body.tv #comments{top:36px}
   document.body.className=isLive?'live':'tv';
   var box=$('flvplayer_container'), main=$('led-main');
   if(!isLive){ main.appendChild($('title')); main.appendChild($('pulse')); }
+  // The panels the client shows of this page, in crop coordinates: the Stage wall's banner strip
+  // and main LED, or a TV's whole crop. Each is outlined and labelled with its size and offset
+  // on the diagnostic page, and listed in its meta text.
+  var panels=isLive?[[7,7,543,53,'banner'],[7,65,543,382,'main']]:[[0,0,486,343,'main']];
+  function panelText(p){ return p[4]+' '+p[2]+'x'+p[3]+(p[0]||p[1]?' at '+p[0]+','+p[1]:''); }
+  var panelsText=(function(){ var t=[]; for(var i=0;i<panels.length;i++) t.push(panelText(panels[i])); return t.join('   '); })();
   function corners(rects){
     for(var r=0;r<rects.length;r++){
       var x=rects[r][0], y=rects[r][1], w=rects[r][2], h=rects[r][3], n=rects[r][4];
       if(n){
         var p=document.createElement('div'); p.className='panel';
         p.style.left=x+'px'; p.style.top=y+'px'; p.style.width=w+'px'; p.style.height=h+'px';
-        var lab=document.createElement('div'); lab.className='lab'; lab.innerHTML=n; p.appendChild(lab);
+        var lab=document.createElement('div'); lab.className='lab'; lab.textContent=panelText(rects[r]); p.appendChild(lab);
         box.appendChild(p);
       }
       var cs=[[x,y],[x+w-12,y],[x,y+h-12],[x+w-12,y+h-12]];
@@ -102,7 +108,7 @@ body.tv #comments{top:36px}
     }
   }
   // Corner markers on the boxes the panels actually show.
-  corners(isLive?[[7,7,543,53,'top'],[7,65,543,382,'main']]:[[0,0,486,343,'']]);
+  corners(panels);
   var q={}, search=(window.location.search||'').substring(1).split('&');
   for(var i=0;i<search.length;i++){ if(!search[i]) continue; var kv=search[i].split('='); try{ q[decodeURIComponent(kv[0])]=decodeURIComponent((kv[1]||'').replace(/\+/g,' ')); }catch(e){ q[kv[0]]=kv[1]; } }
   var params=[]; for(var k in q) if(q.hasOwnProperty(k)) params.push(k+'='+q[k]);
@@ -557,6 +563,8 @@ body.tv #comments{top:36px}
     meta.appendChild(document.createTextNode(kind+' ('+path+')'));
     meta.appendChild(document.createElement('br'));
     meta.appendChild(document.createTextNode(params.length?params.join(' & '):'no parameters'));
+    meta.appendChild(document.createElement('br'));
+    meta.appendChild(document.createTextNode('panels: '+panelsText));
     meta.appendChild(document.createElement('br'));
     meta.appendChild(document.createTextNode('mode: '+mode+'   clock: '+s+'s   volume: '+state.volume+(state.mute?' (muted)':'')));
     meta.appendChild(document.createElement('br'));

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -175,8 +175,18 @@ body.tv #comments{top:36px}
   function effectiveKey(v){ return keyOf(v) || (roomTv ? '100010' : ''); }
   // crop:sw/sh:cx/cy: the hook renders the picture at sw x sh and paints the box-sized window
   // starting at cx,cy of it (zoom in, or cut a region out). For electron: sw/sh is the browser's
-  // layout viewport. Published as crop=sw,sh,cx,cy.
-  function cropOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^crop:(\d+)\/(\d+):(\d+)\/(\d+)$/i.exec(w[i]); if(m) return [+m[1],+m[2],+m[3],+m[4]].join(','); } return ''; }
+  // layout viewport. extend:l/t/r/b is the same worked out from the box b (that much more on
+  // each side, the window at l,t): a page laid out wider than the panel with its edges cut
+  // off. Published as crop=sw,sh,cx,cy; a crop word wins over extend.
+  function cropOf(v,b){
+    var w=(v||'').split(' '), ext=null;
+    for(var i=1;i<w.length;i++){
+      var m=/^crop:(\d+)\/(\d+):(\d+)\/(\d+)$/i.exec(w[i]); if(m) return [+m[1],+m[2],+m[3],+m[4]].join(',');
+      var x=/^extend:(\d+)\/(\d+)\/(\d+)\/(\d+)$/i.exec(w[i]); if(x) ext=[+x[1],+x[2],+x[3],+x[4]];
+    }
+    if(ext&&b) return [b[2]+ext[0]+ext[2], b[3]+ext[1]+ext[3], ext[0], ext[1]].join(',');
+    return '';
+  }
   // scrollx:N, scrolly:N, or scroll:x/y: document offset the off-screen browser (electron:) enforces.
   // Null when no scroll extra is present (the hook then shows scrollbars again).
   function scrollOf(v){
@@ -208,7 +218,7 @@ body.tv #comments{top:36px}
     return t;
   }
   function publish(){
-    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=effectiveKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src,b), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=effectiveKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
     document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
       +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -47,6 +47,7 @@ body.tv #comments{top:36px}
 .panel .lab{position:absolute;left:4px;top:2px;font-size:11px;color:#f80}
 .card{position:absolute;background:#0d0b1a;color:#e8e6f0;text-align:center;font-family:Verdana,Arial,sans-serif;font-weight:bold;overflow:hidden}
 .card .w{position:absolute;left:0;width:100%;letter-spacing:4px}
+.card .k{position:absolute;right:10px;top:0;height:100%;display:flex;align-items:center;font:bold 16px/20px "MS Gothic","ＭＳ ゴシック",monospace;letter-spacing:0;color:#e8e6f0}
 </style></head><body>
 <div id="navi"></div>
 <div id="flvplayer_container">
@@ -242,20 +243,43 @@ body.tv #comments{top:36px}
   }
   // "title": a title card, "aisp-emu" centred in each panel on a dark background ('all'), or
   // on the Stage banner alone ('top') while the main panel plays something and nothing else
-  // claims the banner.
-  var cards=[];
+  // claims the banner. That banner shows what plays instead as soon as the hook has told this
+  // page its title (window.aisp, pushed as it changes): the video's title from yt-dlp or the
+  // embed, a browser source's own document.title.
+  var cards=[], bannerCard=null;
+  function bannerText(){ return media&&media.active&&media.title?media.title:'aisp-emu'; }
+  function fitBanner(){
+    if(!bannerCard) return;
+    var t=bannerCard.text, w=bannerCard.width, fs=bannerCard.size, text=bannerText(), own=text==='aisp-emu';
+    // A video's play time in the right corner, the way the room TV's clock page shows it;
+    // nothing for a live stream (no duration).
+    var k=bannerCard.clock, vod=media&&media.active&&media.duration>0, reserve=0;
+    if(vod){
+      if(!k){ k=document.createElement('div'); k.className='k'; bannerCard.card.appendChild(k); bannerCard.clock=k; }
+      k.textContent=clock(media.position)+' / '+clock(media.duration);
+      reserve=k.offsetWidth+16;
+    } else if(k){ bannerCard.card.removeChild(k); bannerCard.clock=null; }
+    // The text sits in a span of its own width (the line is full-width), so it can be measured;
+    // a long title shrinks down to a floor, then clips: one line, no wrap. It stays centred, so
+    // the clock's width is kept free on both sides.
+    t.textContent=''; var span=document.createElement('span'); span.textContent=text; t.appendChild(span);
+    t.style.letterSpacing=own?'4px':'1px';
+    t.style.left=reserve+'px'; t.style.width=(w-2*reserve)+'px'; t.style.overflow='hidden';
+    do { t.style.fontSize=fs+'px'; t.style.lineHeight=fs+'px'; t.style.top=Math.round((bannerCard.height-fs)/2)+'px'; fs-=2; } while(span.offsetWidth>w-16-2*reserve&&fs>=14);
+  }
   function showTitleCard(mode){
     for(var i=0;i<cards.length;i++) box.removeChild(cards[i]);
-    cards=[];
+    cards=[]; bannerCard=null;
     if(!mode) return;
     var rects=isLive?(mode==='top'?[[7,7,543,53,26]]:[[7,7,543,53,26],[7,65,543,382,56]]):(mode==='top'?[]:[[0,0,486,343,48]]);
     for(var r=0;r<rects.length;r++){
       var x=rects[r][0], y=rects[r][1], w=rects[r][2], h=rects[r][3], fs=rects[r][4];
       var c=document.createElement('div'); c.className='card';
       c.style.left=x+'px'; c.style.top=y+'px'; c.style.width=w+'px'; c.style.height=h+'px';
-      var t=document.createElement('div'); t.className='w'; t.style.fontSize=fs+'px'; t.style.lineHeight=fs+'px'; t.style.top=Math.round((h-fs)/2)+'px'; t.innerHTML='aisp-emu';
+      var t=document.createElement('div'); t.className='w'; t.style.fontSize=fs+'px'; t.style.lineHeight=fs+'px'; t.style.top=Math.round((h-fs)/2)+'px'; t.style.whiteSpace='nowrap'; t.innerHTML='aisp-emu';
       c.appendChild(t);
       box.appendChild(c); cards.push(c);
+      if(mode==='top'){ bannerCard={card:c,text:t,width:w,height:h,size:fs,clock:null}; fitBanner(); }
     }
   }
   var boxFrame=null, keyFill=null;
@@ -434,6 +458,7 @@ body.tv #comments{top:36px}
   }
   // Redraws the pages that show live values; the scroller picks its text up at its next spawn.
   function renderOverlay(){
+    fitBanner();
     if(clockEl){
       var t=clockText(), spans=clockEl.getElementsByTagName('span');
       for(var i=0;i<spans.length;i++) if(spans[i].firstChild.nodeValue!==t) spans[i].firstChild.nodeValue=t;

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -554,7 +554,31 @@ body.tv #comments{top:36px}
   // media title, duration, position, playing state; see the hook's page_state.cpp) and calls
   // this on every change. Shown in the diagnostics line for now.
   var media=null;
-  window.onAisp=function(m){ media=m; renderOverlay(); };
+  window.onAisp=function(m){ media=m; renderOverlay(); tellFrames(); };
+  // The frame pages (main:<url> under the main panel, banner:<url> on the Stage strip) get the
+  // same state this page gets from the hook, relayed by postMessage since they may come from
+  // another origin: {type:'aisp', media:<window.aisp>, screen:{route, kind, params, src, main,
+  // banner}} on every update, when a frame (re)loads, and on request ({type:'aisp:get'} from
+  // the frame). /ai-sp/aisp-frame.js wraps this into the primary page's own interface for a
+  // frame page: window.aisp, window.onAisp, the 'aisp' document event, plus window.aispFrame.
+  function frameMessage(){
+    return { type:'aisp', media:media, screen:{ route:path, kind:kind, params:q, src:src, main:mainOf(src), banner:bannerOf(src) } };
+  }
+  function tellFrames(){
+    var msg=frameMessage();
+    var frames=[frame,bannerFrame];
+    for(var i=0;i<frames.length;i++){
+      var f=frames[i];
+      if(f.style.display==='none'||!f.src||f.src==='about:blank') continue;
+      try{ if(f.contentWindow) f.contentWindow.postMessage(msg,'*'); }catch(e){}
+    }
+  }
+  frame.onload=tellFrames; bannerFrame.onload=tellFrames;
+  window.addEventListener('message',function(e){
+    var d=e.data;
+    if(!d||d.type!=='aisp:get'||!e.source) return;
+    try{ e.source.postMessage(frameMessage(),'*'); }catch(err){}
+  });
   function esc(v){ return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
   function clock(n){ n=Math.floor(n||0); return Math.floor(n/60)+':'+('0'+(n%60)).slice(-2); }
   setInterval(function(){

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -154,6 +154,9 @@ body.tv #comments{top:36px}
   function wordOf(v,name){ var w=(v||'').split(' '), re=new RegExp('^'+name+':(https?://.+)$','i'); for(var i=1;i<w.length;i++){ var m=re.exec(w[i]); if(m) return m[1]; } return ''; }
   function mainPageOf(v){ return wordOf(v,'main'); }
   function bannerOf(v){ return wordOf(v,'banner'); }
+  // run:<url>: a script the hook's browser host runs in an electron: source's page once loaded;
+  // an http(s) URL or a root-relative path of this server's, passed on as is.
+  function runOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++){ var m=/^run:((?:https?:\/\/|\/)[^;\s]+)$/i.exec(w[i]); if(m) return m[1]; } return ''; }
   function rawPageOf(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++) if(isPage(w[i])) return w[i]; return ''; }
   function hasBox(v){ var w=(v||'').split(' '); for(var i=1;i<w.length;i++) if(/^box:/i.test(w[i])) return true; return false; }
   // The main panel, in crop coordinates: a TV shows all of its crop, the Stage wall its main LED.
@@ -242,7 +245,7 @@ body.tv #comments{top:36px}
   function publish(){
     var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src,b), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=publishedKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(stream&&clearable?';clear=1':'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(runOf(src)?';run='+runOf(src):'')+(k?';key='+k:'')+(stream&&clearable?';clear=1':'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
       +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');
     // The client forwards volume, and flushes a pending comment-visibility toggle, only while
     // the state is playing or paused; it reads the word from this element's innerHTML.

--- a/aisp.Server/wwwroot/screen/screen.html
+++ b/aisp.Server/wwwroot/screen/screen.html
@@ -37,6 +37,9 @@ body.tv #comments{top:36px}
 .c{position:absolute;white-space:nowrap;font:bold 28px/32px "MS Gothic","ＭＳ ゴシック",monospace;height:32px}
 .c span{position:absolute;left:0;top:0;color:#000}
 .c span.f{color:#fff}
+.c.k{font-size:20px;line-height:24px;height:24px}
+.d{position:absolute;left:8px;top:8px;right:8px;bottom:8px;background:#101018;color:#fff;font:13px/17px "MS Gothic","ＭＳ ゴシック",monospace;padding:8px;overflow:hidden;white-space:pre-wrap;word-break:break-all}
+.d b{color:#ffd166;font-weight:normal}
 #outside{position:absolute;left:9px;top:600px;font-size:12px;color:#888}
 .ret{position:absolute;left:520px;font-size:12px;color:#00f}
 .corner{position:absolute;width:12px;height:12px;background:#f80}
@@ -126,7 +129,12 @@ body.tv #comments{top:36px}
   // otherwise off). The client never sets it on its own: its panel button is an empty case in
   // the binary, and only the server's set-comment-visible notify (or the launcher hook filling
   // that case in) reaches ext_setCommentVisible. It starts over on every re-navigation.
-  state.comment=/;comment=1(?:;|$)/.test(document.title||'');
+  // The overlay the comment button cycles through, 0 off; comment=1 starts it on page 1 (see
+  // overlayNames). Every press reaches this page as ext_setCommentVisible(true) and is the
+  // next page, round to off after the last; false (the server's notify) is off. The launcher hook asks
+  // ext_isCommentVisible after each press to set the button glyph, so this page decides.
+  state.overlay=/;comment=1(?:;|$)/.test(document.title||'')?1:0;
+  var overlayNames=['off','id','title','clock','info'];
   var frame=$('frame'), bannerFrame=$('banner');
   function isPage(v){ return /^https?:\/\//i.test(v); }
   // "<main> [main:<url>] [banner:<url>] [<url>] [box:x/y/w/h] ...": the main source goes to the
@@ -167,12 +175,14 @@ body.tv #comments{top:36px}
   }
   // The source's own key wins if it has one; otherwise the comment overlay forces the bare
   // DirectDraw key on so its text (drawn outside the key colour) survives the hook's video fill.
-  // A room TV is keyed whether or not comments are shown: the hook composites the page over the
-  // video by key colour, and switching it between keyed and plain on a toggle races the page's
-  // repaint, which shows one frame of the page's black base and indicator before the video
-  // returns. Keying a TV-sized box every frame costs nothing noticeable, so the toggle only
-  // hides the comment layer.
-  function effectiveKey(v){ return keyOf(v) || (roomTv ? '100010' : ''); }
+  // Two keys: fillKey is what this page always paints under the video on a room TV, so any
+  // frame of it the hook has (also the one it kept from before a toggle) carries the key
+  // colour; publishedKey is what the title tells the hook, and that goes on only while the
+  // comment overlay is up. Off, the page is not drawn at all (clear=1, the same colour) and the
+  // video is plain; on, the hook composites by key over a frame that already has the colour, so
+  // the switch never shows the page's black base.
+  function fillKey(v){ return keyOf(v) || (roomTv ? '100010' : ''); }
+  function publishedKey(v){ return keyOf(v) || (roomTv && state.overlay ? '100010' : ''); }
   // crop:sw/sh:cx/cy: the hook renders the picture at sw x sh and paints the box-sized window
   // starting at cx,cy of it (zoom in, or cut a region out). For electron: sw/sh is the browser's
   // layout viewport. extend:l/t/r/b is the same worked out from the box b (that much more on
@@ -217,10 +227,14 @@ body.tv #comments{top:36px}
     for(var i=1;i<w.length;i++){ var m=/^(start|offset|paused):([0-9.]+)$/i.exec(w[i]); if(m) t[m[1].toLowerCase()]=+m[2]; }
     return t;
   }
+  // clear=1: nothing of this page shows and the hook paints the stream over its clear colour
+  // (the key colour) alone, so its page paint stops too. Set by applySource when the video box
+  // is the whole crop with nothing of the page over it: a plain TV, with comments off.
+  var clearable=false;
   function publish(){
-    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src,b), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=effectiveKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
+    var m=mainOf(src), b=geometry(src).crop, browser=/^electron:/i.test(m), cr=cropOf(src,b), sc=browser?scrollOf(src):null, sca=browser?scaleOf(src):0, k=publishedKey(src), f=fpsOf(src), ro=rolloffOf(src), pn=panOf(src), tl=timelineOf(src);
     var stream=m&&!isPage(m)&&m!=='blank'&&m!=='title';
-    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
+    document.title='aisp:vol='+state.volume+';mute='+(state.mute?1:0)+';box='+b.join(',')+(cr?';crop='+cr:'')+(sc?';scrollx='+sc[0]+';scrolly='+sc[1]:'')+(sca?';scale='+sca:'')+(k?';key='+k:'')+(stream&&clearable?';clear=1':'')+(f?';fps='+f:'')+(ro?';rolloff='+ro:'')+(pn?';pan=1':'')
       +(tl.start?';start='+tl.start+';offset='+tl.offset+(tl.paused?';paused='+tl.paused:''):'')+(state.paused?';hold=1':'')+(stream?';src='+m:'');
     // The client forwards volume, and flushes a pending comment-visibility toggle, only while
     // the state is playing or paused; it reads the word from this element's innerHTML.
@@ -321,15 +335,18 @@ body.tv #comments{top:36px}
   }
   function hide(f){ f.style.display='none'; if(f.src) f.src='about:blank'; }
   function applySource(){
-    var m=mainOf(src), mp=mainPageOf(src), bn=bannerOf(src), raw=rawPageOf(src), g=geometry(src), vb=g.crop, k=effectiveKey(src);
+    var m=mainOf(src), mp=mainPageOf(src), bn=bannerOf(src), raw=rawPageOf(src), g=geometry(src), vb=g.crop, k=fillKey(src);
     var ox=isLive?0:9, oy=isLive?0:15, cw=isLive?950:486, ch=isLive?520:343; // the crop inside the page
     var rawFrame=raw&&!isPage(m)&&(hasBox(src)||!!k), rawBanner=raw&&!rawFrame;
     // The built-in gold frame and key fill are only for a box without a frame page: a frame
     // page paints around (and, keyed, over) the video itself. The comment overlay is the same
     // box again, on top, while comments are on.
     var videoBox=m&&!isPage(m)&&m!=='blank'&&!mp&&!rawFrame?vb:null;
+    var comments=!!videoBox&&roomTv&&state.overlay>0;
     showBoxFrame(videoBox, k);
-    updateCommentLayer(videoBox&&roomTv&&state.comment?vb:null);
+    updateCommentLayer(comments?vb:null);
+    // The whole crop is video and nothing of the page (frame, banner, comments) is over it.
+    clearable=!!videoBox&&!comments&&!bn&&!rawBanner&&vb[0]===0&&vb[1]===0&&vb[2]===cw&&vb[3]===ch;
     showGrid(m==='calibrate');
     showRects(/^c:/i.test(m)?m.substring(2):null);
     var diagnostic = !m || m==='calibrate' || /^c:/i.test(m);
@@ -360,10 +377,13 @@ body.tv #comments{top:36px}
     var mid=(q.movieid||mainOf(src)||'aisp-emu').replace(/\s*\bn:\d+\b/gi,'').trim();
     return mid||'aisp-emu';
   }
+  // What the flying text says: page 1 the movie id, page 2 the title the hook pushed (the id
+  // until there is one).
+  function overlayText(){ return state.overlay===2&&media&&media.title?media.title:commentText(); }
   // One flying comment: the text drawn 8 times in black, offset a pixel in every direction,
   // with one more in colour on top, so it stays legible over anything without anti-aliasing.
-  function makeComment(text,color){
-    var d=document.createElement('div'); d.className='c';
+  function makeComment(text,color,cls){
+    var d=document.createElement('div'); d.className='c'+(cls?' '+cls:'');
     var offs=[[-1,-1],[0,-1],[1,-1],[-1,0],[1,0],[-1,1],[0,1],[1,1],[0,0]];
     for(var i=0;i<offs.length;i++){
       var s=document.createElement('span');
@@ -383,7 +403,7 @@ body.tv #comments{top:36px}
   function spawnComment(){
     var cl=$('commentLayer'), bw=cl.clientWidth, bh=cl.clientHeight;
     if(bw<=0||bh<=0) return;
-    var d=makeComment(commentText(),'#fff'), w=d.offsetWidth||220;
+    var d=makeComment(overlayText(),'#fff'), w=d.offsetWidth||220;
     var speed=(bw+w)/(commentCrossMs/commentTickMs);
     d.style.top='8px'; d.style.left=bw+'px';
     comment={el:d,x:bw,speed:speed,w:w};
@@ -394,33 +414,65 @@ body.tv #comments{top:36px}
     c.x-=c.speed; c.el.style.left=Math.round(c.x)+'px';
     if(c.x+c.w<0){ cl.removeChild(c.el); comment=null; }
   }
+  // Page 3: the play time in the corner, the way the old broadcast clocks sat; with the total
+  // when the hook knows one. Page 4: everything the hook pushed, on a panel.
+  var clockEl=null, infoEl=null;
+  function clockText(){
+    if(!media||!media.active) return '--:--';
+    return clock(media.position)+(media.duration?' / '+clock(media.duration):'');
+  }
+  function infoText(){
+    if(!media) return 'no state from the hook yet';
+    var m=media, rows=[['title',m.title||'(none)'],['source',m.source],['kind',m.kind],['url',m.url||'(none)'],
+      ['time',clock(m.position)+(m.duration?' / '+clock(m.duration):'')+'  elapsed '+clock(m.elapsed)],
+      ['state',(m.active?(m.playing?'playing':'not playing'):'no session')+(m.paused?', paused':'')],
+      ['status',m.status||'(none)'],['fps',m.fps],['box',(m.box||[]).join(',')+(m.crop&&m.crop.length?'  crop '+m.crop.join(','):'')],
+      ['overlay',overlayNames[state.overlay]+' ('+state.overlay+')']];
+    var out='';
+    for(var i=0;i<rows.length;i++) out+='<b>'+rows[i][0]+'</b>  '+esc(rows[i][1])+'\n';
+    return out;
+  }
+  // Redraws the pages that show live values; the scroller picks its text up at its next spawn.
+  function renderOverlay(){
+    if(clockEl){
+      var t=clockText(), spans=clockEl.getElementsByTagName('span');
+      for(var i=0;i<spans.length;i++) if(spans[i].firstChild.nodeValue!==t) spans[i].firstChild.nodeValue=t;
+      // The div has no width of its own (its spans are absolute): measure one span.
+      clockEl.style.left=(clockEl.parentNode.clientWidth-(spans.length?spans[0].offsetWidth:0)-10)+'px';
+    }
+    if(infoEl) infoEl.innerHTML=infoText();
+  }
   // Sized and positioned to the video box (crop-space, like the key fill it sits over) while
-  // comments are on; torn down and hidden otherwise.
+  // an overlay page is on; torn down and hidden otherwise.
   function updateCommentLayer(vb){
     var cl=$('commentLayer');
-    if(!vb){
-      if(commentTimer){ clearInterval(commentTimer); commentTimer=null; }
-      if(comment){ cl.removeChild(comment.el); comment=null; }
-      cl.style.display='none';
-      return;
-    }
+    if(commentTimer){ clearInterval(commentTimer); commentTimer=null; }
+    if(comment){ cl.removeChild(comment.el); comment=null; }
+    if(clockEl){ cl.removeChild(clockEl); clockEl=null; }
+    if(infoEl){ cl.removeChild(infoEl); infoEl=null; }
+    if(!vb){ cl.style.display='none'; return; }
     cl.style.left=vb[0]+'px'; cl.style.top=vb[1]+'px'; cl.style.width=vb[2]+'px'; cl.style.height=vb[3]+'px';
     cl.style.display='block';
     // showBoxFrame just above appended a fresh key fill after this div in the DOM, which would
     // otherwise paint over it (later siblings stack on top with no z-index set anywhere here);
-    // move it back to the end so the comments stay above the key colour, not hidden under it.
+    // move it back to the end so the overlay stays above the key colour, not hidden under it.
     box.appendChild(cl);
-    if(!commentTimer) commentTimer=setInterval(commentStep,commentTickMs);
+    if(state.overlay===1||state.overlay===2) commentTimer=setInterval(commentStep,commentTickMs);
+    else if(state.overlay===3){ clockEl=makeComment(clockText(),'#fff','k'); clockEl.style.top='8px'; renderOverlay(); }
+    else if(state.overlay===4){ infoEl=document.createElement('div'); infoEl.className='d'; cl.appendChild(infoEl); renderOverlay(); }
   }
   function updateComments(){
     var el=$('comments'); if(!el) return;
-    el.textContent=state.comment?'💬 on':'💬 off';
-    el.style.color=state.comment?'#8f8':'#888';
+    el.textContent='💬 '+overlayNames[state.overlay];
+    el.style.color=state.overlay?'#8f8':'#888';
   }
   updateComments();
   var retTop=600;
-  // Getters hand back their value through an element the client reads by id and then removes.
+  // Getters return their value; the client calls them with no argument and wraps the value in an
+  // element of its own that it reads by id and removes. Given a name (a test, or the launcher
+  // hook reading a getter directly), an element with the value is left for the caller instead.
   function ret(name,value){
+    if(!name) return value;
     var d=document.createElement('div'); d.id=name; d.className='ret'; d.style.top=(retTop+=14)+'px';
     d.innerText=String(value); d.value=String(value); document.body.appendChild(d); return value;
   }
@@ -434,11 +486,11 @@ body.tv #comments{top:36px}
   ext.ext_setMute=function(m){ note('ext_setMute '+m); state.mute=!!m; publish(); };
   ext.ext_setPlayheadTime=function(t){ note('ext_setPlayheadTime '+t); state.playhead=Number(t)||0; };
   ext.ext_setVolume=function(n){ note('ext_setVolume '+n); state.volume=Math.max(0,Math.min(100,Math.round(Number(n)))); publish(); };
-  ext.ext_setCommentVisible=function(b){ note('ext_setCommentVisible '+b); state.comment=!!b; updateComments(); applySource(); };
+  ext.ext_setCommentVisible=function(b){ note('ext_setCommentVisible '+b); state.overlay=b?(state.overlay+1)%overlayNames.length:0; updateComments(); applySource(); };
   ext.ext_setRepeat=function(b){ note('ext_setRepeat '+b); state.repeat=!!b; };
   ext.ext_isMute=function(r){ note('ext_isMute -> '+r); return ret(r, state.mute?1:0); };
   ext.ext_getVolume=function(r){ note('ext_getVolume -> '+r); return ret(r, state.volume); };
-  ext.ext_isCommentVisible=function(r){ note('ext_isCommentVisible -> '+r); return ret(r, state.comment?1:0); };
+  ext.ext_isCommentVisible=function(r){ note('ext_isCommentVisible -> '+r); return ret(r, state.overlay?1:0); };
   ext.ext_isRepeat=function(r){ note('ext_isRepeat -> '+r); return ret(r, state.repeat?1:0); };
   ext.ext_getPlayheadTime=function(r){ note('ext_getPlayheadTime -> '+r); return ret(r, Math.floor((new Date().getTime()-t0)/1000)); };
   ext.ext_getTotalTime=function(r){ note('ext_getTotalTime -> '+r); return ret(r, state.total); };
@@ -465,6 +517,13 @@ body.tv #comments{top:36px}
     }catch(e){}
   }
   if(!noPoll) setInterval(pollSource,30000);
+  // The launcher hook keeps window.aisp up to date with what it plays for this page (the
+  // media title, duration, position, playing state; see the hook's page_state.cpp) and calls
+  // this on every change. Shown in the diagnostics line for now.
+  var media=null;
+  window.onAisp=function(m){ media=m; renderOverlay(); };
+  function esc(v){ return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+  function clock(n){ n=Math.floor(n||0); return Math.floor(n/60)+':'+('0'+(n%60)).slice(-2); }
   setInterval(function(){
     var s=Math.floor((new Date().getTime()-t0)/1000);
     while(meta.firstChild) meta.removeChild(meta.firstChild);
@@ -475,6 +534,10 @@ body.tv #comments{top:36px}
     meta.appendChild(document.createTextNode('mode: '+mode+'   clock: '+s+'s   volume: '+state.volume+(state.mute?' (muted)':'')));
     meta.appendChild(document.createElement('br'));
     meta.appendChild(document.createTextNode('source: '+(src||'(none, showing this page)')));
+    if(media&&media.active){
+      meta.appendChild(document.createElement('br'));
+      meta.appendChild(document.createTextNode('media: '+(media.title||'(untitled)')+'   '+clock(media.position)+(media.duration?' / '+clock(media.duration):'')+(media.playing?'':' ('+media.status+')')));
+    }
     pulse.style.background=(s%2)?'#f80':'#0cf';
   },250);
 })();

--- a/aisp.Server/wwwroot/screen/yt-embed.html
+++ b/aisp.Server/wwwroot/screen/yt-embed.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>aisp yt-embed</title>
+<!-- YouTube's player embed for the yte: source (ScreenAssignments), served at
+     /ai-sp/yt-embed?v=<id>[&start=<unix>&offset=<s>[&paused=<unix>]] and shown by the launcher
+     hook's off-screen browser (electron:), which fetches it from wherever it got the screen
+     page. The embed only plays inside a page, hence this one: it fills the window with the
+     player, autoplay with sound, looping the one video (loop needs the playlist set to it,
+     which is also what keeps it from moving on to anything else), no related videos, no
+     annotations. start/offset/paused are the video's shared timeline, the same numbers the
+     screen page publishes.
+     Startup is arranged to buffer once, at the right place: the embed iframe is written first
+     (cued, not playing) so it loads alongside the IFrame API script rather than after it; when
+     the player knows the duration (usually in the cued state) the position is worked out
+     modulo it and the video is loaded with that start, as a one-item playlist so the loop
+     stays. A position within kEdgeSeconds of either end plays from 0 instead (a start only
+     moments ago needs no seek, a tail would show for a moment and loop; the hook's ffmpeg path
+     has the same rule). Only when the duration is not known until playback does it fall back
+     to playing from 0 and seeking. A paused timeline pauses the player at its position once it
+     plays; a live stream (the player says so) is left at the live edge: no seek, no pause. The
+     hook's volume fader reaches the player's <video> through the frame. -->
+<style>html,body{margin:0;padding:0;background:#000;overflow:hidden;width:100%;height:100%}#p,#yt{position:absolute;left:0;top:0;width:100%;height:100%;border:0}</style>
+</head><body>
+<div id="p"></div>
+<script>
+(function(){
+  var q={}, search=(window.location.search||'').substring(1).split('&');
+  for(var i=0;i<search.length;i++){ if(!search[i]) continue; var kv=search[i].split('='); try{ q[decodeURIComponent(kv[0])]=decodeURIComponent(kv[1]||''); }catch(e){} }
+  var id=/^[A-Za-z0-9_-]{1,64}$/.test(q.v||'')?q.v:'';
+  if(!id){ document.body.innerHTML='<div style="color:#888;font:14px monospace;padding:12px">yt-embed: no video id</div>'; return; }
+  var start=+q.start||0, offset=+q.offset||0, paused=+q.paused||0;
+  var kEdgeSeconds=3;
+  // Where the shared timeline is now: the offset plus what has elapsed since start (or until
+  // the pause). Wrapped by the duration once the player knows it.
+  function target(){ var until=paused?paused:Math.floor(new Date().getTime()/1000); return offset+Math.max(0,until-start); }
+  // The position to begin at for a known duration: the timeline modulo it, or 0 near either end.
+  function startPosition(d){ if(!start||!(d>0)) return 0; var pos=target()%d; return (pos<kEdgeSeconds||pos>d-kEdgeSeconds)?0:pos; }
+  var player=null, started=false, live=false;
+  window.aispEmbed={id:id, live:false, started:false, mode:null, position:null};
+
+  // The embed itself, cued (autoplay off) so it loads now, in parallel with the API script;
+  // the player object attaches to it once that script is in.
+  var vars='enablejsapi=1&autoplay=0&loop=1&playlist='+id+'&rel=0&playsinline=1&iv_load_policy=3&controls=0&disablekb=1&fs=0&origin='+encodeURIComponent(window.location.protocol+'//'+window.location.host);
+  var frame=document.createElement('iframe');
+  frame.id='yt'; frame.setAttribute('allow','autoplay; encrypted-media'); frame.setAttribute('frameborder','0');
+  frame.src='https://www.youtube.com/embed/'+id+'?'+vars;
+  document.getElementById('p').appendChild(frame);
+
+  // The player knows whether this is a live stream (isLive; isWindowedLive with a DVR window):
+  // then the shared timeline means nothing, it plays at the live edge and never pauses.
+  // Also the video's title, as this page's own: the launcher hook reports a browser source's
+  // document.title, and the screen page shows it on the Stage banner.
+  function checkLive(){
+    if(!player||typeof player.getVideoData!=='function') return;
+    // A live stream has no duration to speak of; the player says isLive once it knows.
+    var data=player.getVideoData()||{};
+    if(data.title&&document.title!==data.title) document.title=data.title;
+    if(live) return;
+    if(data.isLive||data.isWindowedLive){ live=true; window.aispEmbed.live=true; }
+  }
+  function note(mode,pos){ started=true; window.aispEmbed.started=true; window.aispEmbed.mode=mode; window.aispEmbed.position=pos; }
+  // First play, once the duration is known (or the stream is live): one load at the position.
+  function begin(){
+    if(started||!player) return;
+    checkLive();
+    if(live){ note('live',null); player.playVideo(); return; }
+    var d=player.getDuration();
+    if(!(d>0)) return;
+    var pos=startPosition(d);
+    if(pos>0){ note('load',pos); player.loadPlaylist([id],0,pos); player.setLoop(true); }
+    else { note('play',0); player.playVideo(); }
+  }
+  // Playback began before the duration was known: a live stream (the player says so, or it
+  // still reports no duration while playing), else seek now, unless within the edges.
+  function beginPlaying(){
+    if(started||!player) return;
+    checkLive();
+    var d=player.getDuration();
+    if(live||!(d>0)){ live=true; window.aispEmbed.live=true; note('live',null); return; }
+    var pos=startPosition(d);
+    note('seek',pos);
+    if(pos>0) player.seekTo(pos,true);
+  }
+  // Nothing decided yet a moment after the player was ready (no duration in the cued state: a
+  // live stream, or metadata not in yet): play, and let PLAYING decide.
+  var kickTimer=null;
+  function kick(){ if(kickTimer) return; kickTimer=setTimeout(function(){ kickTimer=null; if(!started&&player) player.playVideo(); },800); }
+  window.onYouTubeIframeAPIReady=function(){
+    player=new YT.Player('yt',{
+      events:{
+        onReady:function(e){
+          if(!player) player=e.target;
+          e.target.setVolume(100);
+          begin();
+          if(!started) kick();
+        },
+        onStateChange:function(e){
+          if(!player) player=e.target;
+          checkLive();
+          if(e.data===YT.PlayerState.CUED){ begin(); if(!started) kick(); }
+          if(e.data===YT.PlayerState.PLAYING){
+            var was=started;
+            beginPlaying();
+            // A paused timeline still needs the media loaded to sit on its frame, so it plays
+            // until it is at its position, then pauses.
+            if(paused&&!live&&(was||started)) player.pauseVideo();
+          }
+          // The playlist loop restarts it; should the player stop at the end anyway, restart it.
+          if(e.data===YT.PlayerState.ENDED&&!paused&&!live){ player.seekTo(0,true); player.playVideo(); }
+        }
+      }
+    });
+  };
+  var s=document.createElement('script'); s.src='https://www.youtube.com/iframe_api'; document.head.appendChild(s);
+})();
+</script>
+</body></html>

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -2277,14 +2277,23 @@ public class CmdExecHandlerTests
                 StringComparison.OrdinalIgnoreCase
             );
 
-            // A video (needs a shared timeline, which channels do not have) is rejected too.
+            // Another channel is rejected too (no indirection chains).
             var modMsgSession = new CapturingPlayerSession { User = mod, UserId = mod.Id };
+            await handler.HandleAsync(
+                BuildCmdExecPayload("/channel", "2", "channel:3"),
+                modMsgSession,
+                TestContext.Current.CancellationToken
+            );
+            Assert.Null(screenAssignments.GetChannelSource(2));
+
+            // A video sticks, looping on the channel's own timeline from the moment it is set.
             await handler.HandleAsync(
                 BuildCmdExecPayload("/channel", "2", "yt:dQw4w9WgXcQ"),
                 modMsgSession,
                 TestContext.Current.CancellationToken
             );
-            Assert.Null(screenAssignments.GetChannelSource(2));
+            Assert.Equal("yt:dQw4w9WgXcQ", screenAssignments.GetChannelSource(2));
+            Assert.NotNull(screenAssignments.GetChannelTimeline(2));
 
             // A moderator's livestream assignment sticks, normalised the same way /screen does.
             await handler.HandleAsync(

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -1197,10 +1197,7 @@ public class CmdExecHandlerTests
                 expectedItems.Count,
                 areaSession.Sent.Count(p => p.Type == PacketType.ItemCreateNotify)
             );
-            Assert.DoesNotContain(
-                areaSession.Sent,
-                p => p.Type == PacketType.ItemUpdateListNotify
-            );
+            Assert.DoesNotContain(areaSession.Sent, p => p.Type == PacketType.ItemUpdateListNotify);
             Assert.Contains(msgSession.Sent, packet => packet.Type == PacketType.CmdExecResponse);
         }
         finally
@@ -1412,10 +1409,7 @@ public class CmdExecHandlerTests
             Assert.Equal(1, inventory.Quantity);
 
             Assert.Equal(1, areaSession.Sent.Count(p => p.Type == PacketType.ItemCreateNotify));
-            Assert.DoesNotContain(
-                areaSession.Sent,
-                p => p.Type == PacketType.ItemUpdateListNotify
-            );
+            Assert.DoesNotContain(areaSession.Sent, p => p.Type == PacketType.ItemUpdateListNotify);
             Assert.Contains(msgSession.Sent, packet => packet.Type == PacketType.CmdExecResponse);
         }
         finally
@@ -2298,12 +2292,13 @@ public class CmdExecHandlerTests
                 modMsgSession,
                 TestContext.Current.CancellationToken
             );
-            Assert.Equal("twitch:someone", screenAssignments.GetChannelSource(2));
+            Assert.Equal("tw:someone", screenAssignments.GetChannelSource(2));
 
             // A room TV tuned to that channel (via channel:2, the same word /screen channel:2
-            // would bind a map to) resolves the assigned stream, not the title card.
+            // would bind a map to) resolves the assigned stream (tw: as the embed, the default),
+            // not the title card.
             Assert.Equal(
-                "streamlink:https://twitch.tv/someone",
+                "electron:https://player.twitch.tv/?channel=someone&parent=aisp.moe",
                 screenAssignments.Resolve("room-tv", "channel:2 n:5", null)
             );
 

--- a/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
+++ b/tests/aisp.Common.Tests/CmdExecHandlerTests.cs
@@ -98,7 +98,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -232,7 +231,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -351,7 +349,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -454,7 +451,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -599,7 +595,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms(["faggot"]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -840,7 +835,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -921,7 +915,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1004,7 +997,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1079,7 +1071,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1172,7 +1163,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1307,7 +1297,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1325,6 +1314,233 @@ public class CmdExecHandlerTests
             var reader = new PacketReader(notify.Payload);
             Assert.Equal((uint)onTvId, reader.ReadUInt());
             Assert.Equal(1u, reader.ReadUInt());
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    // The handler with only what the screen commands need; the rest is stock.
+    private static CmdExecHandler CreateScreenHandler(
+        Microsoft.EntityFrameworkCore.DbContextOptions<MainContext> options,
+        SharedState state,
+        ScreenAssignments? assignments = null
+    ) =>
+        new(
+            state,
+            new MapRepository(new MainContext(options)),
+            new UserRepository(new MainContext(options)),
+            new CharacterRepository(
+                new MainContext(options),
+                NullLogger<CharacterRepository>.Instance
+            ),
+            new MyRoomRepository(new MainContext(options)),
+            new CircleRepository(new MainContext(options)),
+            new StubItemBaseListCache(DefaultClothingItems.Male),
+            CreateDirectMapLinkTransitionService(options, state),
+            CreateModerationService(options, state),
+            new ChatLogRepository(new MainContext(options)),
+            new ReportTicketRepository(new MainContext(options)),
+            TestTextLocaliser.English,
+            new AdventureWorkRepository(new MainContext(options)),
+            WordFilter.FromTerms([]),
+            assignments ?? new ScreenAssignments(),
+            new NicotvRepository(new MainContext(options)),
+            NullLogger<CmdExecHandler>.Instance
+        );
+
+    [Fact]
+    public async Task ScreenCommand_TellsEveryClientOnTheMapToReload_NotOnlyTheStage()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+        try
+        {
+            var ct = TestContext.Current.CancellationToken;
+            // A town map (Akihabara's id range), not the Stage: its screens reload through the
+            // launcher hook, so every client there is told.
+            var mod = CreateUserWithCharacter(1, 8010, "screen-mod", "Screen Mod", 10990100);
+            mod.Role = UserRole.Moderator;
+            var other = CreateUserWithCharacter(2, 8011, "screen-other", "Screen Other", 10990100);
+            var elsewhere = CreateUserWithCharacter(3, 8012, "screen-far", "Screen Far", 10990110);
+            await using (var db = new MainContext(options))
+            {
+                db.Users.AddRange(mod, other, elsewhere);
+                await db.SaveChangesAsync(ct);
+            }
+            var state = new SharedState();
+            var modArea = new CapturingPlayerSession
+            {
+                User = mod,
+                UserId = mod.Id,
+                Character = mod.Characters.First(),
+                CharacterId = 8010,
+                MapId = 10990100,
+            };
+            var otherArea = new CapturingPlayerSession
+            {
+                User = other,
+                UserId = other.Id,
+                Character = other.Characters.First(),
+                CharacterId = 8011,
+                MapId = 10990100,
+            };
+            var farArea = new CapturingPlayerSession
+            {
+                User = elsewhere,
+                UserId = elsewhere.Id,
+                Character = elsewhere.Characters.First(),
+                CharacterId = 8012,
+                MapId = 10990110,
+            };
+            state.RegisterClient(ServerType.Area, modArea);
+            state.RegisterClient(ServerType.Area, otherArea);
+            state.RegisterClient(ServerType.Area, farArea);
+            var msgSession = new CapturingPlayerSession { User = mod, UserId = mod.Id };
+            var handler = CreateScreenHandler(options, state);
+
+            await handler.HandleAsync(BuildCmdExecPayload("screen", "tw:someone"), msgSession, ct);
+
+            foreach (var onTheMap in new[] { modArea, otherArea })
+            {
+                var notify = Assert.Single(
+                    onTheMap.Sent,
+                    p => p.Type == PacketType.NotifyNicoliveReload
+                );
+                Assert.Equal(
+                    ScreenAssignments.ReloadEveryScreen,
+                    new PacketReader(notify.Payload).ReadString()
+                );
+            }
+            Assert.DoesNotContain(farArea.Sent, p => p.Type == PacketType.NotifyNicoliveReload);
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ChannelCommand_ReloadsBoundMapsWholly_AndAutoMapsForThatChannelOnly()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+        try
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var mod = CreateUserWithCharacter(1, 8020, "chan-mod", "Chan Mod", 10990100);
+            mod.Role = UserRole.Moderator;
+            var onAuto = CreateUserWithCharacter(2, 8021, "chan-auto", "Chan Auto", 10990100);
+            var onBound = CreateUserWithCharacter(3, 8022, "chan-bound", "Chan Bound", 10990110);
+            var onOther = CreateUserWithCharacter(4, 8023, "chan-other", "Chan Other", 10990120);
+            var inRoom = CreateUserWithCharacter(5, 8024, "chan-room", "Chan Room", 20_000_000);
+            await using (var db = new MainContext(options))
+            {
+                db.Users.AddRange(mod, onAuto, onBound, onOther, inRoom);
+                await db.SaveChangesAsync(ct);
+            }
+            var state = new SharedState();
+            CapturingPlayerSession Area(User user, uint characterId, uint mapId)
+            {
+                var area = new CapturingPlayerSession
+                {
+                    User = user,
+                    UserId = user.Id,
+                    Character = user.Characters.First(),
+                    CharacterId = characterId,
+                    MapId = mapId,
+                };
+                state.RegisterClient(ServerType.Area, area);
+                return area;
+            }
+            Area(mod, 8020, 10990100);
+            var autoArea = Area(onAuto, 8021, 10990100); // no assignment: screens follow their own tvid
+            var boundArea = Area(onBound, 8022, 10990110);
+            var otherArea = Area(onOther, 8023, 10990120);
+            var roomArea = Area(inRoom, 8024, 20_000_000);
+            var assignments = new ScreenAssignments();
+            assignments.Set(10990110, "channel:7");
+            assignments.Set(10990120, "tw:elsewhere");
+            var msgSession = new CapturingPlayerSession { User = mod, UserId = mod.Id };
+            var handler = CreateScreenHandler(options, state, assignments);
+
+            await handler.HandleAsync(
+                BuildCmdExecPayload("channel", "7", "tw:someone"),
+                msgSession,
+                ct
+            );
+
+            static string ReloadIdSentTo(CapturingPlayerSession area) =>
+                new PacketReader(
+                    Assert.Single(area.Sent, p => p.Type == PacketType.NotifyNicoliveReload).Payload
+                ).ReadString();
+            // Only the screens on channel 7 among those following their own number...
+            Assert.Equal("lv7", ReloadIdSentTo(autoArea));
+            // ...every screen on a map bound to the channel...
+            Assert.Equal(ScreenAssignments.ReloadEveryScreen, ReloadIdSentTo(boundArea));
+            // ...nothing on a map showing something else, or in a room (its TVs have their own notify).
+            Assert.DoesNotContain(otherArea.Sent, p => p.Type == PacketType.NotifyNicoliveReload);
+            Assert.DoesNotContain(roomArea.Sent, p => p.Type == PacketType.NotifyNicoliveReload);
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ScreenReload_IsForAnyone_AndReloadsOnlyTheirOwnClient()
+    {
+        var (connection, options) = TestDb.CreateInMemoryMainContext();
+        try
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var player = CreateUserWithCharacter(1, 8013, "screen-user", "Screen User", 10990100);
+            var neighbour = CreateUserWithCharacter(2, 8014, "screen-nb", "Screen Nb", 10990100);
+            await using (var db = new MainContext(options))
+            {
+                db.Users.AddRange(player, neighbour);
+                await db.SaveChangesAsync(ct);
+            }
+            var state = new SharedState();
+            var playerArea = new CapturingPlayerSession
+            {
+                User = player,
+                UserId = player.Id,
+                Character = player.Characters.First(),
+                CharacterId = 8013,
+                MapId = 10990100,
+            };
+            var neighbourArea = new CapturingPlayerSession
+            {
+                User = neighbour,
+                UserId = neighbour.Id,
+                Character = neighbour.Characters.First(),
+                CharacterId = 8014,
+                MapId = 10990100,
+            };
+            state.RegisterClient(ServerType.Area, playerArea);
+            state.RegisterClient(ServerType.Area, neighbourArea);
+            var msgSession = new CapturingPlayerSession { User = player, UserId = player.Id };
+            var handler = CreateScreenHandler(options, state);
+
+            // A regular user: /screen itself is refused, /screen reload is not.
+            await handler.HandleAsync(BuildCmdExecPayload("screen", "tw:someone"), msgSession, ct);
+            Assert.DoesNotContain(playerArea.Sent, p => p.Type == PacketType.NotifyNicoliveReload);
+
+            await handler.HandleAsync(BuildCmdExecPayload("screen", "reload"), msgSession, ct);
+
+            var notify = Assert.Single(
+                playerArea.Sent,
+                p => p.Type == PacketType.NotifyNicoliveReload
+            );
+            Assert.Equal(
+                ScreenAssignments.ReloadEveryScreenHard,
+                new PacketReader(notify.Payload).ReadString()
+            );
+            Assert.DoesNotContain(
+                neighbourArea.Sent,
+                p => p.Type == PacketType.NotifyNicoliveReload
+            );
         }
         finally
         {
@@ -1391,7 +1607,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1483,7 +1698,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1559,7 +1773,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -1691,7 +1904,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 new ScreenAssignments(),
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -2252,7 +2464,6 @@ public class CmdExecHandlerTests
                 WordFilter.FromTerms([]),
                 screenAssignments,
                 new NicotvRepository(new MainContext(options)),
-                Options.Create(new ServerOptions()),
                 NullLogger<CmdExecHandler>.Instance
             );
 
@@ -2349,7 +2560,6 @@ public class CmdExecHandlerTests
             WordFilter.FromTerms([]),
             new ScreenAssignments(),
             new NicotvRepository(new MainContext(options)),
-            Options.Create(new ServerOptions()),
             NullLogger<CmdExecHandler>.Instance
         );
 

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -516,6 +516,12 @@ public sealed class ScreenAssignmentsTests
             ScreenAssignments.IsValidSource("twl:yueri box:20/20/446/303 crop:892/606:0/0")
         );
         Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972/686"));
+        // extend:l/t/r/b is the crop worked out from the box by the page.
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://x/y extend:0/0/0/200"));
+        Assert.True(ScreenAssignments.IsExtendWord("extend:10/20/30/40"));
+        Assert.False(ScreenAssignments.IsExtendWord("extend:10/20/30"));
+        Assert.False(ScreenAssignments.IsExtendWord("extend:-1/0/0/0"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:https://x/y extend:a/b/c/d"));
         Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:0/686:0/0"));
         Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972/686:-1/0"));
         Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972,686:0,0"));

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -17,16 +17,16 @@ public sealed class ScreenAssignmentsTests
         var time = new TestTime();
         var assignments = new ScreenAssignments(time);
         var t0 = time.Now.ToUnixTimeSeconds();
-        assignments.Set(10990100, " twitch:someone ");
+        assignments.Set(10990100, " twl:someone ");
 
         // A Twitch channel typed into the TV wins, whatever the map says; tw: is the short form.
         Assert.Equal(
             "streamlink:https://twitch.tv/me",
-            assignments.Resolve("room-tv", "twitch:me", 10990100)
+            assignments.Resolve("room-tv", "twl:me", 10990100)
         );
         Assert.Equal(
             "streamlink:https://twitch.tv/averylongchannelname",
-            assignments.Resolve("room-tv", " tw:averylongchannelname ", null)
+            assignments.Resolve("room-tv", " twl:averylongchannelname ", null)
         );
         // twe: is the Twitch player embed in the off-screen browser.
         Assert.Equal(
@@ -40,7 +40,14 @@ public sealed class ScreenAssignmentsTests
         );
         Assert.Equal(
             $"yt-dlp:https://www.youtube.com/watch?v=dQw4w9WgXcQ start:{t0} offset:0",
-            assignments.Resolve("room-tv", "yt:dQw4w9WgXcQ", null)
+            assignments.Resolve("room-tv", "ytd:dQw4w9WgXcQ", null)
+        );
+        // yte: is YouTube's own embed in the off-screen browser, through this server's page
+        // (root-relative: the hook fetches it from wherever the screen page came from), with
+        // the shared timeline in the page's URL as well as in the words.
+        Assert.Equal(
+            $"electron:/ai-sp/yt-embed?v=dQw4w9WgXcQ&start={t0}&offset=0 start:{t0} offset:0",
+            assignments.Resolve("room-tv", "yte:dQw4w9WgXcQ", null)
         );
         // Nico: a bare lv… id is a live programme through streamlink, sm… a video through yt-dlp.
         Assert.Equal(
@@ -76,8 +83,8 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("blank", assignments.Resolve("room-tv", "streamlink:https://x/y", null));
         Assert.Equal("blank", assignments.Resolve("room-tv", "yt-dlp:https://x/y", null));
         // Ids with characters the sites do not use never reach a command line.
-        Assert.Equal("blank", assignments.Resolve("room-tv", "tw:some\"one", null));
-        Assert.Equal("blank", assignments.Resolve("room-tv", "yt:abc&x=1", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "twl:some\"one", null));
+        Assert.Equal("blank", assignments.Resolve("room-tv", "ytd:abc&x=1", null));
         Assert.Equal("blank", assignments.Resolve("room-tv", "smx", null));
         // Anything else typed falls back to the map, then to blank.
         Assert.Equal(
@@ -93,12 +100,102 @@ public sealed class ScreenAssignmentsTests
     }
 
     [Fact]
+    public void ShortForms_GoWhereTheServerIsConfigured_EmbedsByDefault()
+    {
+        var time = new TestTime();
+        var t0 = time.Now.ToUnixTimeSeconds();
+        // tw: and yt: are kept as typed (twitch: is an alias of tw:) and resolved at hook time.
+        Assert.Equal("tw:someone", ScreenAssignments.Normalize("twitch:someone"));
+        Assert.Equal("tw:someone", ScreenAssignments.Normalize("tw:someone"));
+        var embeds = new ScreenAssignments(time);
+        Assert.Equal(
+            "electron:https://player.twitch.tv/?channel=someone&parent=aisp.moe",
+            embeds.Resolve("room-tv", "twitch:someone", null)
+        );
+        Assert.Equal(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0}&offset=0 start:{t0} offset:0",
+            embeds.Resolve("room-tv", "yt:abc123", null)
+        );
+        Assert.True(ScreenAssignments.IsBrowserSource("tw:someone"));
+        Assert.True(ScreenAssignments.IsBrowserSource("yt:abc123"));
+        var decoded = new ScreenAssignments(
+            time,
+            new ScreenSourceDefaults(TwitchEmbed: false, YouTubeEmbed: false)
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            decoded.Resolve("room-tv", "tw:someone", null)
+        );
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=abc123 start:{t0} offset:0",
+            decoded.Resolve("room-tv", "yt:abc123", null)
+        );
+        var decodedDefaults = new ScreenSourceDefaults(TwitchEmbed: false, YouTubeEmbed: false);
+        Assert.False(ScreenAssignments.IsBrowserSource("tw:someone", decodedDefaults));
+        Assert.False(ScreenAssignments.IsBrowserSource("yt:abc123", decodedDefaults));
+        // The explicit forms never move.
+        Assert.Equal(
+            "electron:https://player.twitch.tv/?channel=someone&parent=aisp.moe",
+            decoded.Resolve("room-tv", "twe:someone", null)
+        );
+        Assert.Equal(
+            "streamlink:https://twitch.tv/someone",
+            embeds.Resolve("room-tv", "twl:someone", null)
+        );
+        // From the server's settings.
+        Assert.Equal(
+            new ScreenSourceDefaults(false, false),
+            ScreenSourceDefaults.FromOptions(
+                new aisp.Common.Config.ScreenOptions { Twitch = "streamlink", YouTube = "yt-dlp" }
+            )
+        );
+        Assert.Equal(
+            ScreenSourceDefaults.Default,
+            ScreenSourceDefaults.FromOptions(new aisp.Common.Config.ScreenOptions())
+        );
+    }
+
+    [Fact]
+    public void YouTubeEmbed_CarriesTheTimelineInItsPageUrl()
+    {
+        var time = new TestTime();
+        var assignments = new ScreenAssignments(time);
+        var t0 = time.Now.ToUnixTimeSeconds();
+        assignments.Set(30000002, "yte:abc123 box:10/20/300/200");
+        // The embed page gets the timeline in its query (the off-screen browser only sees the
+        // URL), the words follow for the page's title; the extras stay.
+        Assert.Equal(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0}&offset=0 box:10/20/300/200 start:{t0} offset:0",
+            assignments.Resolve("channel-screen", null, 30000002)
+        );
+        time.Now = time.Now.AddSeconds(10);
+        Assert.True(assignments.Control(30000002, "pause"));
+        time.Now = time.Now.AddSeconds(5);
+        Assert.StartsWith(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0}&offset=0&paused={t0 + 10} ",
+            assignments.Resolve("channel-screen", null, 30000002)
+        );
+        // Seeking moves start and offset (still paused: the pause time moves too), so the URL
+        // changes and the browser restarts there.
+        Assert.True(assignments.Control(30000002, "seek:100"));
+        Assert.StartsWith(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0 + 15}&offset=100&paused={t0 + 15} ",
+            assignments.Resolve("channel-screen", null, 30000002)
+        );
+        Assert.True(assignments.Control(30000002, "resume"));
+        Assert.StartsWith(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0 + 15}&offset=100 ",
+            assignments.Resolve("channel-screen", null, 30000002)
+        );
+    }
+
+    [Fact]
     public void Videos_CarryASharedTimeline_ThatPauseResumeAndSeekMove()
     {
         var time = new TestTime();
         var assignments = new ScreenAssignments(time);
         var t0 = time.Now.ToUnixTimeSeconds();
-        assignments.Set(30000001, "yt:abc123");
+        assignments.Set(30000001, "ytd:abc123");
         Assert.Equal(
             $"yt-dlp:https://www.youtube.com/watch?v=abc123 start:{t0} offset:0",
             assignments.Resolve("channel-screen", null, 30000001)
@@ -133,7 +230,7 @@ public sealed class ScreenAssignmentsTests
             assignments.Resolve("channel-screen", null, 30000001)
         );
         // Not a video: nothing to control.
-        assignments.Set(30000001, "tw:someone");
+        assignments.Set(30000001, "twl:someone");
         Assert.False(assignments.Control(30000001, "pause"));
         Assert.False(assignments.Control(30000002, "pause"));
         // The other videos: a Nico video and the vod pattern.
@@ -149,17 +246,20 @@ public sealed class ScreenAssignmentsTests
         // channel, since room instances reuse the same map id.
         Assert.Equal(
             $"yt-dlp:https://www.youtube.com/watch?v=xyz start:{t0 + 17} offset:0",
-            assignments.Resolve("room-tv", "yt:xyz", 10990100, 1)
+            assignments.Resolve("room-tv", "ytd:xyz", 10990100, 1)
         );
-        Assert.True(assignments.ControlMovie(10990100, 1, "yt:xyz", "pause"));
-        Assert.EndsWith($"paused:{t0 + 17}", assignments.Resolve("room-tv", "yt:xyz", 10990100, 1));
+        Assert.True(assignments.ControlMovie(10990100, 1, "ytd:xyz", "pause"));
+        Assert.EndsWith(
+            $"paused:{t0 + 17}",
+            assignments.Resolve("room-tv", "ytd:xyz", 10990100, 1)
+        );
         // A different room on the same map (another channel) does not share that pause.
-        Assert.DoesNotContain("paused:", assignments.Resolve("room-tv", "yt:xyz", 10990100, 2));
+        Assert.DoesNotContain("paused:", assignments.Resolve("room-tv", "ytd:xyz", 10990100, 2));
         // Freshly setting the same id restarts that room's TV, even mid-playback.
-        assignments.SetMovie(10990100, 1, "yt:xyz");
+        assignments.SetMovie(10990100, 1, "ytd:xyz");
         Assert.EndsWith(
             $"start:{t0 + 17} offset:0",
-            assignments.Resolve("room-tv", "yt:xyz", 10990100, 1)
+            assignments.Resolve("room-tv", "ytd:xyz", 10990100, 1)
         );
         Assert.True(assignments.ControlMovie(10990100, 1, "pattern:vod", "pause"));
         Assert.EndsWith(
@@ -168,12 +268,12 @@ public sealed class ScreenAssignmentsTests
         );
         Assert.False(assignments.ControlMovie(10990100, 1, "pattern:live", "pause"));
         Assert.False(assignments.ControlMovie(10990100, 1, "yt-dlp:https://x/y", "pause"));
-        Assert.False(assignments.ControlMovie(10990100, 1, "tw:someone", "pause"));
+        Assert.False(assignments.ControlMovie(10990100, 1, "twl:someone", "pause"));
         // SetMovie ignores anything that is not a video: no timeline appears for it.
-        assignments.SetMovie(10990100, 1, "tw:someone");
+        assignments.SetMovie(10990100, 1, "twl:someone");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone",
-            assignments.Resolve("room-tv", "tw:someone", 10990100, 1)
+            assignments.Resolve("room-tv", "twl:someone", 10990100, 1)
         );
     }
 
@@ -184,7 +284,7 @@ public sealed class ScreenAssignmentsTests
         // Unassigned town screens show the title card.
         Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
 
-        assignments.Set(10990100, "tw:someone https://x/banner");
+        assignments.Set(10990100, "twl:someone https://x/banner");
         // Town screens also get the map's screen position for rolloff, unless the source names one.
         Assert.EndsWith(
             " rolloff:-17340/375/-20639/1000/12000/1/0",
@@ -192,39 +292,39 @@ public sealed class ScreenAssignmentsTests
         );
         // The short form keeps the map's position and only sets the range; rolloff:flat turns
         // the rolloff off; a short form on a map without a known screen is dropped.
-        assignments.Set(10990100, "tw:someone rolloff:500/6000");
+        assignments.Set(10990100, "twl:someone rolloff:500/6000");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/500/6000/1/0",
             assignments.Resolve("channel-screen", null, 10990100)
         );
         // Four numbers add the gains to fade between, keeping the map's position.
-        assignments.Set(10990100, "tw:someone rolloff:500/6000/0.8/0.25");
+        assignments.Set(10990100, "twl:someone rolloff:500/6000/0.8/0.25");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone rolloff:-17340/375/-20639/500/6000/0.8/0.25",
             assignments.Resolve("channel-screen", null, 10990100)
         );
-        assignments.Set(10990100, "tw:someone rolloff:flat");
+        assignments.Set(10990100, "twl:someone rolloff:flat");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone",
             assignments.Resolve("channel-screen", null, 10990100)
         );
-        assignments.Set(30000001, "tw:someone rolloff:500/6000");
+        assignments.Set(30000001, "twl:someone rolloff:500/6000");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone",
             assignments.Resolve("channel-screen", null, 30000001)
         );
-        assignments.Set(10990100, "tw:someone rolloff:1/2/3/10/20");
+        assignments.Set(10990100, "twl:someone rolloff:1/2/3/10/20");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone rolloff:1/2/3/10/20/1/0",
             assignments.Resolve("channel-screen", null, 10990100)
         );
         // Seven is the hook's own form and passes through unchanged.
-        assignments.Set(10990100, "tw:someone rolloff:1/2/3/10/20/0.5/0.1");
+        assignments.Set(10990100, "twl:someone rolloff:1/2/3/10/20/0.5/0.1");
         Assert.Equal(
             "streamlink:https://twitch.tv/someone rolloff:1/2/3/10/20/0.5/0.1",
             assignments.Resolve("channel-screen", null, 10990100)
         );
-        assignments.Set(10990100, "tw:someone https://x/banner");
+        assignments.Set(10990100, "twl:someone https://x/banner");
         // The page gets the hook's form; the stored assignment keeps the friendly one.
         Assert.Equal(
             "streamlink:https://twitch.tv/someone https://x/banner rolloff:-17340/375/-20639/1000/12000/1/0",
@@ -234,7 +334,7 @@ public sealed class ScreenAssignmentsTests
             "streamlink:https://twitch.tv/someone https://x/banner rolloff:-17340/375/-20639/1000/12000/1/0",
             assignments.Resolve("live-watch", null, 10990100)
         );
-        Assert.Equal("twitch:someone https://x/banner", assignments.Get(10990100));
+        Assert.Equal("twl:someone https://x/banner", assignments.Get(10990100));
         // The typed ids keep their friendly form in the assignment too.
         assignments.Set(10990100, "sm9 pan");
         Assert.Equal("nico:sm9 pan", assignments.Get(10990100));
@@ -254,15 +354,26 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsTwitchSource("tw:yueri"));
         Assert.False(ScreenAssignments.IsTwitchSource("tw:"));
         Assert.False(ScreenAssignments.IsTwitchSource("tw:yue-ri"));
+        Assert.True(ScreenAssignments.IsTwitchStreamlinkSource("twl:yueri"));
         Assert.True(ScreenAssignments.IsTwitchEmbedSource("twe:ironmouse"));
         Assert.True(ScreenAssignments.IsBrowserSource("twe:ironmouse"));
         Assert.False(ScreenAssignments.IsTwitchSource("twe:ironmouse"));
+        Assert.False(ScreenAssignments.IsTwitchSource("twl:ironmouse"));
         Assert.True(ScreenAssignments.IsYouTubeVideoSource("yt:dQw4w9WgXcQ"));
         Assert.True(ScreenAssignments.IsVideoSource("yt:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsYouTubeDlpSource("ytd:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsVideoSource("ytd:dQw4w9WgXcQ"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("ytd:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsYouTubeEmbedSource("yte:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsVideoSource("yte:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsBrowserSource("yte:dQw4w9WgXcQ"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("yte:dQw4w9WgXcQ"));
+        Assert.False(ScreenAssignments.IsYouTubeEmbedSource("yte:"));
+        Assert.False(ScreenAssignments.IsYouTubeEmbedSource("yte:bad/id"));
         Assert.True(ScreenAssignments.IsYouTubeLiveSource("ytl:jfKfPfyJRdk"));
         Assert.False(ScreenAssignments.IsVideoSource("ytl:jfKfPfyJRdk"));
-        Assert.False(ScreenAssignments.IsYouTubeVideoSource("yt:"));
-        Assert.False(ScreenAssignments.IsYouTubeVideoSource("yt:a/b"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("ytd:"));
+        Assert.False(ScreenAssignments.IsYouTubeVideoSource("ytd:a/b"));
         Assert.True(ScreenAssignments.IsNicoLiveSource("lv351315472"));
         Assert.True(ScreenAssignments.IsNicoVideoSource("sm11273499"));
         Assert.True(ScreenAssignments.IsVideoSource("sm11273499"));
@@ -284,9 +395,9 @@ public sealed class ScreenAssignmentsTests
         foreach (
             var typed in new[]
             {
-                "tw:yueri",
+                "twl:yueri",
                 "twe:yueri",
-                "yt:abc",
+                "ytd:abc",
                 "ytl:abc",
                 "lv1",
                 "sm1",
@@ -317,7 +428,7 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsPageUrl("HTTP://host/page"));
         Assert.True(ScreenAssignments.IsValidSource("HTTP://host/page"));
         Assert.False(ScreenAssignments.IsTypedSource("HTTP://host/page"));
-        Assert.False(ScreenAssignments.IsPageUrl("twitch:yueri"));
+        Assert.False(ScreenAssignments.IsPageUrl("twl:yueri"));
         // Not sources: the hook's own raw yt-dlp form (yt: and sm… are the typed ways in), other
         // browser hosts, and the raw forms with nothing after the prefix.
         Assert.False(ScreenAssignments.IsValidSource("yt-dlp:https://x/y"));
@@ -366,9 +477,11 @@ public sealed class ScreenAssignmentsTests
         );
         // A bare second URL is the raw form (a banner page, or with a box a whole-crop frame
         // page); main:<url> and banner:<url> name the panel. All three have to be pages.
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri https://example.test/banner"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri https://example.test/banner"));
         Assert.True(ScreenAssignments.IsValidSource("blank https://example.test/banner"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri banner:https://example.test/banner"));
+        Assert.True(
+            ScreenAssignments.IsValidSource("twl:yueri banner:https://example.test/banner")
+        );
         Assert.True(
             ScreenAssignments.IsValidSource(
                 "twe:ironmouse box:40/30/406/240 key main:https://example.test/frame.html banner:https://example.test/top"
@@ -376,63 +489,65 @@ public sealed class ScreenAssignmentsTests
         );
         Assert.True(ScreenAssignments.IsMainWord("main:http://x/"));
         Assert.False(ScreenAssignments.IsMainWord("main:x"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri main:frame.html"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri banner:ftp://x"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri twitch:other"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri main:frame.html"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri banner:ftp://x"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri twitch:other"));
         Assert.Equal(
             "streamlink:https://twitch.tv/yueri box:0/0/10/10 main:https://x/f",
-            ScreenAssignments.ToHookSource("tw:yueri box:0/0/10/10 main:https://x/f")
+            ScreenAssignments.ToHookSource("twl:yueri box:0/0/10/10 main:https://x/f")
         );
         // A box:x/y/w/h word places the video inside the crop; the page can put HTML around it.
         // Slashes because the client splits chat arguments on commas.
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri https://x/ box:0/76/635/441"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri box:20/20"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri box:20,20,446,303"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri box:20/20/446/303"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri https://x/ box:0/76/635/441"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri box:20/20"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri box:20,20,446,303"));
         // key / key:RRGGBB colour-keys the video into the page's own pixels.
         Assert.True(
-            ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303 key https://x/frame")
+            ScreenAssignments.IsValidSource("twl:yueri box:20/20/446/303 key https://x/frame")
         );
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri key:100010"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri key:12"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri key:zzzzzz"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri key:100010"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri key:12"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri key:zzzzzz"));
         // crop:sw/sh:cx/cy renders at sw x sh and shows the box-sized window at cx,cy of it.
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri crop:972/686:243/171"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri box:20/20/446/303 crop:892/606:0/0"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972/686"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:0/686:0/0"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972/686:-1/0"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri crop:972,686:0,0"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri crop:972/686:243/171"));
+        Assert.True(
+            ScreenAssignments.IsValidSource("twl:yueri box:20/20/446/303 crop:892/606:0/0")
+        );
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972/686"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:0/686:0/0"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972/686:-1/0"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri crop:972,686:0,0"));
         // fps:N picks ffmpeg's constant output rate, from the set that maps to whole samples.
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri fps:60"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri fps:24"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri pan"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri fps:60"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri fps:24"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri pan"));
         var panned = new ScreenAssignments();
-        panned.Set(19001003, "tw:yueri pan");
+        panned.Set(19001003, "twl:yueri pan");
         Assert.Equal(
             "streamlink:https://twitch.tv/yueri pan rolloff:0/352.1/1567/1000/12000/1/0",
             panned.Resolve("channel-screen", null, 19001003)
         );
         Assert.True(
-            ScreenAssignments.IsValidSource("tw:yueri rolloff:-17340/375/-20639/1000/12000")
+            ScreenAssignments.IsValidSource("twl:yueri rolloff:-17340/375/-20639/1000/12000")
         );
         Assert.True(
-            ScreenAssignments.IsValidSource("tw:yueri rolloff:-17340/375/-20639/1000/12000/1/0.2")
+            ScreenAssignments.IsValidSource("twl:yueri rolloff:-17340/375/-20639/1000/12000/1/0.2")
         );
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri rolloff:1/2/3"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri rolloff:1/2/3/4/5/6"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:500/6000"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:500/6000/1/0.3"));
-        Assert.True(ScreenAssignments.IsValidSource("tw:yueri rolloff:flat"));
-        Assert.False(ScreenAssignments.IsValidSource("tw:yueri audio:500/6000"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri rolloff:1/2/3"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri rolloff:1/2/3/4/5/6"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri rolloff:500/6000"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri rolloff:500/6000/1/0.3"));
+        Assert.True(ScreenAssignments.IsValidSource("twl:yueri rolloff:flat"));
+        Assert.False(ScreenAssignments.IsValidSource("twl:yueri audio:500/6000"));
         Assert.Null(ScreenAssignments.DefaultRolloffWord(30000001));
         Assert.Equal(
             "streamlink:https://twitch.tv/yueri box:20/20/446/303",
-            ScreenAssignments.ToHookSource("tw:yueri box:20/20/446/303")
+            ScreenAssignments.ToHookSource("twl:yueri box:20/20/446/303")
         );
         Assert.Equal(
-            "twitch:yueri https://x/",
-            ScreenAssignments.Normalize(" tw:yueri  https://x/ ")
+            "twl:yueri https://x/",
+            ScreenAssignments.Normalize(" twl:yueri  https://x/ ")
         );
         // Browser extras: scroll pans the document, scale is zoom.
         Assert.True(ScreenAssignments.IsValidSource("electron:https://example.com scrollx:120"));
@@ -513,9 +628,9 @@ public sealed class ScreenAssignmentsTests
 
         // Assigning the channel is what both a room TV tuned to it and a map bound to it follow,
         // with no further wiring: it is the same channel:2 word either way.
-        assignments.SetChannelSource(2, "tw:someone");
+        assignments.SetChannelSource(2, "twl:someone");
         // Normalized to its long form, like any other assignment.
-        Assert.Equal("twitch:someone", assignments.GetChannelSource(2));
+        Assert.Equal("twl:someone", assignments.GetChannelSource(2));
         // A live source drops any extras on the reference (n: included), same as any other
         // typed, non-video room-tv source already does: it needs no shared timeline to key.
         Assert.Equal(
@@ -564,7 +679,7 @@ public sealed class ScreenAssignmentsTests
         Assert.True(ScreenAssignments.IsChannelSource("channel:auto"));
 
         var assignments = new ScreenAssignments();
-        assignments.SetChannelSource(1, "tw:one");
+        assignments.SetChannelSource(1, "twl:one");
 
         // No tvid= on the request at all: an unassigned map shows the title card, for the routes
         // and requests that never carry one (live-watch, screen, or a channel-screen request
@@ -594,7 +709,7 @@ public sealed class ScreenAssignmentsTests
         // An explicit, non-channel /screen assignment always wins over the requesting screen's
         // own tvid=: a moderator's direct assignment is authoritative, and a town screen's own
         // tvid= must never override it.
-        assignments.Set(40000003, "tw:two");
+        assignments.Set(40000003, "twl:two");
         Assert.Equal(
             "streamlink:https://twitch.tv/two",
             assignments.Resolve("channel-screen", null, 40000003, requestTvId: 1)

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -468,6 +468,13 @@ public sealed class ScreenAssignmentsTests
             "streamlink:https://live.nicovideo.jp/watch/lv351315472",
             ScreenAssignments.ToHookSource("lv351315472")
         );
+        Assert.True(ScreenAssignments.IsRunWord("run:/ai-sp/run/nicolive-player.js"));
+        Assert.True(ScreenAssignments.IsRunWord("run:https://x/a.js"));
+        Assert.False(ScreenAssignments.IsRunWord("run:"));
+        Assert.False(ScreenAssignments.IsRunWord("run://x"));
+        Assert.False(ScreenAssignments.IsRunWord("run:ftp://x"));
+        Assert.True(ScreenAssignments.IsValidSource("electron:https://x/ run:/ai-sp/run/a.js"));
+        Assert.False(ScreenAssignments.IsValidSource("electron:https://x/ run:a.js"));
         Assert.Equal(
             "yt-dlp:https://www.nicovideo.jp/watch/lv351315472",
             ScreenAssignments.ToHookSource("lv351315472:vod")

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -762,4 +762,31 @@ public sealed class ScreenAssignmentsTests
             assignments.Resolve("channel-screen", null, 40000003, requestTvId: 1)
         );
     }
+
+    [Fact]
+    public void ReloadIds_ScopeTheHookToOneChannel_OrToEveryScreen()
+    {
+        Assert.Equal("lv0", ScreenAssignments.ReloadForChannel(0));
+        Assert.Equal("lv99", ScreenAssignments.ReloadForChannel(99));
+        Assert.Equal("lv100", ScreenAssignments.ReloadEveryScreen);
+        Assert.Equal("lv200", ScreenAssignments.ReloadEveryScreenHard);
+        Assert.Equal(ScreenAssignments.ReloadEveryScreen, ScreenAssignments.ReloadForChannel(100));
+        Assert.Equal(ScreenAssignments.ReloadEveryScreen, ScreenAssignments.ReloadForChannel(1234));
+    }
+
+    [Fact]
+    public void FollowsChannel_TellsBoundMaps_FromAutoOnes_FromTheRest()
+    {
+        var assignments = new ScreenAssignments();
+        assignments.Set(2, "channel:3");
+        assignments.Set(3, "channel:auto");
+        assignments.Set(4, "channel:4 key");
+        assignments.Set(5, "tw:someone");
+        Assert.Equal(ScreenAssignments.ChannelFollowing.Auto, assignments.FollowsChannel(1, 3));
+        Assert.Equal(ScreenAssignments.ChannelFollowing.Bound, assignments.FollowsChannel(2, 3));
+        Assert.Equal(ScreenAssignments.ChannelFollowing.None, assignments.FollowsChannel(2, 4));
+        Assert.Equal(ScreenAssignments.ChannelFollowing.Auto, assignments.FollowsChannel(3, 3));
+        Assert.Equal(ScreenAssignments.ChannelFollowing.Bound, assignments.FollowsChannel(4, 4));
+        Assert.Equal(ScreenAssignments.ChannelFollowing.None, assignments.FollowsChannel(5, 3));
+    }
 }

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -49,18 +49,39 @@ public sealed class ScreenAssignmentsTests
             $"electron:/ai-sp/yt-embed?v=dQw4w9WgXcQ&start={t0}&offset=0 start:{t0} offset:0",
             assignments.Resolve("room-tv", "yte:dQw4w9WgXcQ", null)
         );
-        // Nico: a bare lv… id is a live programme through streamlink, sm… a video through yt-dlp.
+        // Nico: a bare lv… id is a live programme, sm… a video, both as their watch pages in the
+        // off-screen browser by default, each with a run: script of this server's: the live one
+        // presses the player's own fullscreen button (Nico has no live embed and the page refuses
+        // framing), the video one pins the page's video element over the box and drives it, with
+        // the shared timeline in the page URL's fragment.
         Assert.Equal(
-            "streamlink:https://live.nicovideo.jp/watch/lv351315472",
+            "electron:https://live.nicovideo.jp/watch/lv351315472 run:/ai-sp/run/nicolive-player.js",
             assignments.Resolve("room-tv", "lv351315472", 10990100)
         );
         Assert.Equal(
-            "streamlink:https://live.nicovideo.jp/watch/lv1",
+            "electron:https://live.nicovideo.jp/watch/lv1 run:/ai-sp/run/nicolive-player.js",
             assignments.Resolve("room-tv", "nico:lv1", null)
         );
         Assert.Equal(
-            $"yt-dlp:https://www.nicovideo.jp/watch/sm11273499 start:{t0} offset:0",
+            $"electron:https://www.nicovideo.jp/watch/sm11273499#start={t0}&offset=0 run:/ai-sp/run/nicovideo-player.js start:{t0} offset:0",
             assignments.Resolve("room-tv", "sm11273499", 10990100)
+        );
+        // The explicit forms pick the path regardless of the server's default.
+        Assert.Equal(
+            "streamlink:https://live.nicovideo.jp/watch/lv351315472",
+            assignments.Resolve("room-tv", "nnl:lv351315472", null)
+        );
+        Assert.Equal(
+            $"yt-dlp:https://www.nicovideo.jp/watch/sm11273499 start:{t0} offset:0",
+            assignments.Resolve("room-tv", "nnd:sm11273499", null)
+        );
+        Assert.Equal(
+            $"yt-dlp:https://www.nicovideo.jp/watch/lv1 start:{t0} offset:0",
+            assignments.Resolve("room-tv", "nnd:lv1:vod", null)
+        );
+        Assert.Equal(
+            $"electron:https://www.nicovideo.jp/watch/sm9#start={t0}&offset=0 run:/ai-sp/run/nicovideo-player.js start:{t0} offset:0",
+            assignments.Resolve("room-tv", "nne:sm9", null)
         );
         // The hook's test pattern, live or as a video on the shared timeline; bare pattern is live.
         Assert.Equal("pattern:live", assignments.Resolve("room-tv", "pattern:live", null));
@@ -130,6 +151,31 @@ public sealed class ScreenAssignmentsTests
             $"yt-dlp:https://www.youtube.com/watch?v=abc123 start:{t0} offset:0",
             decoded.Resolve("room-tv", "yt:abc123", null)
         );
+        // Nico the same way: nn: (a bare id, or nico:) follows the server, nne:/nnd:/nnl: do not.
+        Assert.Equal("nn:sm9", ScreenAssignments.Normalize("nico:sm9"));
+        Assert.Equal("nn:lv1", ScreenAssignments.Normalize("lv1"));
+        Assert.True(ScreenAssignments.IsBrowserSource("sm9"));
+        Assert.True(ScreenAssignments.IsBrowserSource("lv1"));
+        Assert.True(ScreenAssignments.IsBrowserSource("nne:sm9"));
+        Assert.False(ScreenAssignments.IsBrowserSource("nnd:sm9"));
+        Assert.False(ScreenAssignments.IsBrowserSource("nnl:lv1"));
+        var nicoDecoded = new ScreenAssignments(
+            time,
+            new ScreenSourceDefaults(NicoVideoEmbed: false, NicoLiveEmbed: false)
+        );
+        Assert.Equal(
+            $"yt-dlp:https://www.nicovideo.jp/watch/sm9 start:{t0} offset:0",
+            nicoDecoded.Resolve("room-tv", "sm9", null)
+        );
+        Assert.Equal(
+            "streamlink:https://live.nicovideo.jp/watch/lv1",
+            nicoDecoded.Resolve("room-tv", "lv1", null)
+        );
+        Assert.True(ScreenAssignments.IsVideoSource("nne:sm9"));
+        Assert.True(ScreenAssignments.IsVideoSource("nnd:lv1:vod"));
+        Assert.False(ScreenAssignments.IsVideoSource("nne:lv1"));
+        Assert.True(ScreenAssignments.IsTypedSource("nne:lv1"));
+        Assert.True(ScreenAssignments.IsTypedSource("nnl:lv1"));
         var decodedDefaults = new ScreenSourceDefaults(TwitchEmbed: false, YouTubeEmbed: false);
         Assert.False(ScreenAssignments.IsBrowserSource("tw:someone", decodedDefaults));
         Assert.False(ScreenAssignments.IsBrowserSource("yt:abc123", decodedDefaults));
@@ -337,7 +383,7 @@ public sealed class ScreenAssignmentsTests
         Assert.Equal("twl:someone https://x/banner", assignments.Get(10990100));
         // The typed ids keep their friendly form in the assignment too.
         assignments.Set(10990100, "sm9 pan");
-        Assert.Equal("nico:sm9 pan", assignments.Get(10990100));
+        Assert.Equal("nn:sm9 pan", assignments.Get(10990100));
         assignments.Set(10990100, "pattern");
         Assert.Equal("pattern:live", assignments.Get(10990100));
 
@@ -462,11 +508,20 @@ public sealed class ScreenAssignmentsTests
         );
         Assert.Equal(
             "yt-dlp:https://www.nicovideo.jp/watch/sm9",
-            ScreenAssignments.ToHookSource("sm9")
+            ScreenAssignments.ToHookSource("nnd:sm9")
         );
         Assert.Equal(
             "streamlink:https://live.nicovideo.jp/watch/lv351315472",
-            ScreenAssignments.ToHookSource("lv351315472")
+            ScreenAssignments.ToHookSource("nnl:lv351315472")
+        );
+        Assert.Equal(
+            "electron:https://www.nicovideo.jp/watch/sm9 run:/ai-sp/run/nicovideo-player.js",
+            ScreenAssignments.ToHookSource("sm9")
+        );
+        // A caller's own run: word stands in for the live page's default one.
+        Assert.Equal(
+            "electron:https://live.nicovideo.jp/watch/lv351315472 run:https://x/mine.js key",
+            ScreenAssignments.ToHookSource("lv351315472 run:https://x/mine.js key")
         );
         Assert.True(ScreenAssignments.IsRunWord("run:/ai-sp/run/nicolive-player.js"));
         Assert.True(ScreenAssignments.IsRunWord("run:https://x/a.js"));

--- a/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
+++ b/tests/aisp.Common.Tests/ScreenAssignmentsTests.cs
@@ -370,6 +370,7 @@ public sealed class ScreenAssignmentsTests
         Assert.False(ScreenAssignments.IsYouTubeVideoSource("yte:dQw4w9WgXcQ"));
         Assert.False(ScreenAssignments.IsYouTubeEmbedSource("yte:"));
         Assert.False(ScreenAssignments.IsYouTubeEmbedSource("yte:bad/id"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("yte:dQw4w9WgXcQ"));
         Assert.True(ScreenAssignments.IsYouTubeLiveSource("ytl:jfKfPfyJRdk"));
         Assert.False(ScreenAssignments.IsVideoSource("ytl:jfKfPfyJRdk"));
         Assert.False(ScreenAssignments.IsYouTubeVideoSource("ytd:"));
@@ -592,11 +593,11 @@ public sealed class ScreenAssignmentsTests
     }
 
     [Fact]
-    public void Channels_AreSharedByNumber_LivestreamOnlyAndIndirectFromRoomTvsAndMaps()
+    public void Channels_AreSharedByNumber_AndIndirectFromRoomTvsAndMaps()
     {
-        // Livestream sources are valid channel content; a video (needs a timeline) or another
-        // channel (no indirection chains) is not.
-        Assert.True(ScreenAssignments.IsValidChannelContentSource("tw:someone"));
+        // Livestreams and videos are valid channel content; another channel (no indirection
+        // chains) is not.
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("twl:someone"));
         Assert.True(ScreenAssignments.IsValidChannelContentSource("twe:someone"));
         Assert.True(ScreenAssignments.IsValidChannelContentSource("ytl:abc"));
         Assert.True(ScreenAssignments.IsValidChannelContentSource("lv351315472"));
@@ -605,15 +606,15 @@ public sealed class ScreenAssignmentsTests
         // A web page is channel content too (the help has always said so): the screen page shows
         // it over the video box, the same as a page given to /screen directly.
         Assert.True(ScreenAssignments.IsValidChannelContentSource("https://example.com/rain.html"));
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("yt:dQw4w9WgXcQ"));
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("sm11273499"));
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("lv351315472:vod"));
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("pattern:vod"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("ytd:dQw4w9WgXcQ"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("sm11273499"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("lv351315472:vod"));
+        Assert.True(ScreenAssignments.IsValidChannelContentSource("pattern:vod"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("channel:2"));
         Assert.False(ScreenAssignments.IsValidChannelContentSource("blank"));
         // A channel is purely a source map: framing belongs on whoever references it, not here.
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone box:0/0/10/10"));
-        Assert.False(ScreenAssignments.IsValidChannelContentSource("tw:someone key"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("twl:someone box:0/0/10/10"));
+        Assert.False(ScreenAssignments.IsValidChannelContentSource("twl:someone key"));
         Assert.False(
             ScreenAssignments.IsValidChannelContentSource("https://example.com/rain.html key")
         );
@@ -670,6 +671,46 @@ public sealed class ScreenAssignmentsTests
         Assert.Null(assignments.GetChannelSource(2));
         Assert.Equal("title", assignments.Resolve("room-tv", "channel:2 n:9", null));
         Assert.Equal("title", assignments.Resolve("channel-screen", null, 10990100));
+    }
+
+    [Fact]
+    public void ChannelVideos_LoopFromWhenTheChannelWasSet_OnOneTimelineForEveryFollower()
+    {
+        var time = new TestTime();
+        var assignments = new ScreenAssignments(time);
+        var t0 = time.Now.ToUnixTimeSeconds();
+        assignments.Set(10990100, "channel:2");
+        time.Now = time.Now.AddSeconds(20);
+        assignments.SetChannelSource(2, "ytd:abc123");
+        // The channel's timeline (from when it was set, not from when the map was bound) reaches
+        // a room TV tuned to it and a map bound to it alike; the map's framing extras stay.
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=abc123 start:{t0 + 20} offset:0",
+            assignments.Resolve("room-tv", "channel:2 n:9", null)
+        );
+        Assert.Equal(
+            $"yt-dlp:https://www.youtube.com/watch?v=abc123 {ScreenAssignments.DefaultRolloffWord(10990100)} start:{t0 + 20} offset:0",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        // No pause or seek for a channel: /screen's controls act on a map's own video only.
+        Assert.False(assignments.Control(10990100, "pause"));
+        Assert.EndsWith(
+            $"start:{t0 + 20} offset:0",
+            assignments.Resolve("channel-screen", null, 10990100)
+        );
+        // The embed carries it in its page URL too.
+        assignments.SetChannelSource(3, "yte:abc123");
+        time.Now = time.Now.AddSeconds(5);
+        Assert.Equal(
+            $"electron:/ai-sp/yt-embed?v=abc123&start={t0 + 20}&offset=0 start:{t0 + 20} offset:0",
+            assignments.Resolve("room-tv", "channel:3 n:9", null)
+        );
+        // Setting the channel again restarts its video from now.
+        assignments.SetChannelSource(2, "ytd:abc123");
+        Assert.EndsWith(
+            $"start:{t0 + 25} offset:0",
+            assignments.Resolve("room-tv", "channel:2 n:9", null)
+        );
     }
 
     [Fact]


### PR DESCRIPTION
adds support for the electron embed versions of yt/twitch/nico, adds a /screen reload for users to force their screen locally to refresh (server pushes reload message), and adds the reload messages for akiba/etc map screens to update instantly so they don't need to poll the http for updates anymore

updated shortcodes allow choosing mode
ytd:id -> using yt-dlp, yte:id -> using embed, yt: -> defaults to embed
twl:user -> using streamlink, twd:user -> using yt-dlp (vod), twe: -> embed, tw: -> embed
nnl: -> streamlink nico, nne: -> embed nico, sm123 -> embed, lv123 -> embed